### PR TITLE
Add optional events list control for partner reports

### DIFF
--- a/app/api/partners/edit/[slug]/route.ts
+++ b/app/api/partners/edit/[slug]/route.ts
@@ -76,6 +76,7 @@ const db = client.db(config.dbName);
       categorizedHashtags: partner.categorizedHashtags || {},
       styleId: partner.styleId ? partner.styleId.toString() : undefined,
       reportTemplateId: partner.reportTemplateId ? partner.reportTemplateId.toString() : undefined,
+      showEventsList: partner.showEventsList ?? true, // Default to true for backward compatibility
       createdAt: partner.createdAt,
       updatedAt: partner.updatedAt,
       // WHAT: Partner stats for content editing (reportText*, reportImage*)

--- a/app/api/partners/report/[slug]/route.ts
+++ b/app/api/partners/report/[slug]/route.ts
@@ -126,6 +126,7 @@ const db = client.db(config.dbName);
         categorizedHashtags: partner.categorizedHashtags || {},
         styleId: partner.styleId ? partner.styleId.toString() : undefined,
         reportTemplateId: partner.reportTemplateId ? partner.reportTemplateId.toString() : undefined,
+        showEventsList: partner.showEventsList ?? true, // Default to true for backward compatibility
         createdAt: partner.createdAt,
         updatedAt: partner.updatedAt,
         // WHAT: Include partner-level stats (reportText*, reportImage*) for chart display

--- a/app/api/partners/route.ts
+++ b/app/api/partners/route.ts
@@ -62,6 +62,7 @@ const db = client.db(config.dbName);
       clickerSetId: partner.clickerSetId?.toString(),
       googleSheetsUrl: partner.googleSheetsUrl,
       viewSlug: partner.viewSlug,
+      showEventsList: partner.showEventsList ?? true, // Default to true for backward compatibility
       createdAt: partner.createdAt,
       updatedAt: partner.updatedAt
     }));
@@ -91,7 +92,7 @@ const db = client.db(config.dbName);
 export async function PUT(request: NextRequest) {
   try {
     const body = await request.json();
-    const { partnerId, name, emoji, logoUrl, hashtags, categorizedHashtags, stats, styleId, reportTemplateId, googleSheetsUrl, clickerSetId } = body;
+    const { partnerId, name, emoji, logoUrl, hashtags, categorizedHashtags, stats, styleId, reportTemplateId, googleSheetsUrl, clickerSetId, showEventsList } = body;
 
     if (!partnerId) {
       return NextResponse.json(
@@ -119,6 +120,7 @@ const db = client.db(config.dbName);
     if (reportTemplateId !== undefined) updateData.reportTemplateId = reportTemplateId ? new ObjectId(reportTemplateId) : null;
     if (clickerSetId !== undefined) updateData.clickerSetId = clickerSetId ? new ObjectId(clickerSetId) : null;
     if (googleSheetsUrl !== undefined) updateData.googleSheetsUrl = googleSheetsUrl || null;
+    if (showEventsList !== undefined) updateData.showEventsList = showEventsList;
 
     // WHAT: Update partner document
     // WHY: Persist partner-level content changes

--- a/app/partner-edit/[slug]/page.tsx
+++ b/app/partner-edit/[slug]/page.tsx
@@ -17,6 +17,7 @@ interface Partner {
   styleId?: string;
   reportTemplateId?: string;
   clickerSetId?: string;
+  showEventsList?: boolean; // WHAT: Controls visibility of events list on partner report page
   createdAt: string;
   updatedAt: string;
   // WHAT: Partner-level stats for text and image content only

--- a/app/partner-report/[slug]/PartnerEventsList.tsx
+++ b/app/partner-report/[slug]/PartnerEventsList.tsx
@@ -35,6 +35,7 @@ interface Event {
 interface PartnerEventsListProps {
   events: Event[];
   partnerName: string;
+  showEventsList?: boolean; // WHAT: Controls whether to show the events list
 }
 
 /**
@@ -48,9 +49,12 @@ interface PartnerEventsListProps {
  * - Quick stats summary (images, fans)
  * - Links to individual event reports
  * - Responsive grid layout
+ * - Optional visibility control via showEventsList prop
  */
-export default function PartnerEventsList({ events, partnerName }: PartnerEventsListProps) {
-  if (!events || events.length === 0) {
+export default function PartnerEventsList({ events, partnerName, showEventsList = true }: PartnerEventsListProps) {
+  // WHAT: Respect showEventsList setting
+  // WHY: Partners can control whether events list appears on their report page
+  if (!showEventsList || !events || events.length === 0) {
     return null;
   }
 

--- a/app/partner-report/[slug]/page.tsx
+++ b/app/partner-report/[slug]/page.tsx
@@ -216,7 +216,11 @@ export default function PartnerReportPage() {
 
         {/* Related Events List - Shows all events for this partner */}
         {events.length > 0 && (
-          <PartnerEventsList events={events} partnerName={partner.name} />
+          <PartnerEventsList 
+            events={events} 
+            partnerName={partner.name}
+            showEventsList={partner.showEventsList}
+          />
         )}
       </div>
     </div>

--- a/hooks/useReportData.ts
+++ b/hooks/useReportData.ts
@@ -170,6 +170,7 @@ export interface PartnerReportData {
     _id: string;
     name: string;
     emoji?: string;
+    showEventsList?: boolean; // WHAT: Controls visibility of events list on partner report page
     stats?: Record<string, number | string>;
   };
   events: Array<{


### PR DESCRIPTION
WHAT: Implement showEventsList toggle for partner report pages WHY: Partners need control over whether events list appears on their report page HOW:
- Added showEventsList boolean field to partner data structure
- Added checkbox control in partner edit stats page
- Modified PartnerEventsList component to respect showEventsList setting
- Updated all relevant API endpoints and TypeScript interfaces

FEATURES:
- Checkbox in partner edit page: 'Show Events List on Report Page'
- Auto-saves when toggled (immediate persistence)
- Defaults to true for backward compatibility
- Controls visibility of '[Partner] Events (X)' section

TECHNICAL DETAILS:
- Updated partner API endpoints (GET/PUT) to handle showEventsList field
- Modified PartnerEditorDashboard with toggle UI and save logic
- Enhanced PartnerEventsList component with optional visibility
- Updated TypeScript interfaces across the application
- Maintains existing functionality while adding new control

RESULT: Partners can now hide/show the events list section on their report pages

# Pull Request
Status: Active
Last Updated: 2026-01-11T22:28:38.000Z
Canonical: No
Owner: Architecture

## DoD Profile
- [ ] **Report Rendering & Dashboards** (STRICT)
- [ ] **Infrastructure & Operations** (CRITICAL)
- [ ] **Editor & Builder** (STRICT)
- [ ] **Security & Validation** (CRITICAL)
- [ ] **Documentation** (STANDARD)

## Required Status Checks (ALL must pass before merge)

**CI Gate (Auto-merge enabled):**
- [ ] **Build** - Next.js build succeeds
- [ ] **Type Check** - TypeScript compilation passes (strict mode)
- [ ] **Lint** - ESLint passes (no warnings/errors)
- [ ] **Layout Grammar Guardrail** - No forbidden CSS patterns (`overflow`, `text-overflow`, `line-clamp`)
- [ ] **Dependency Guardrail** - No unapproved dependencies, no vulnerabilities
- [ ] **Date Placeholder Guardrail** - No placeholder dates in tracker/docs
- [ ] **Layout Grammar Test Suite** - All Layout Grammar unit tests pass
- [ ] **Phase 6 Validation Test Suite** - All validation tests pass (if Phase 6+ work)

**Note:** GitHub Auto-merge is enabled. Once all required checks pass, the PR will merge automatically. No manual merge required.

## Context

**Branch:** `[branch-name]`  
**Base:** `[base-branch]`  
**Related Issue/Phase:** [Link or reference]

**Phase 5 File Touches (if any):**
- [ ] No Phase 5 files touched
- [ ] Phase 5 files touched (justified below)

If Phase 5 files were touched, explain why this is required by Task 6.x:

```
[Explanation]
```

## Changes

**What changed:**
- [List files/components changed]

**Why:**
- [Rationale for changes]

**How:**
- [Implementation approach]

## Verification

**Tests:**
- [ ] Unit tests added/updated
- [ ] Integration tests pass
- [ ] Layout Grammar validation tests pass
- [ ] All existing tests pass

**Manual Testing:**
- [ ] Tested locally
- [ ] Verified in preview deployment
- [ ] No console errors
- [ ] No visual regressions

**CI Status:**
- [ ] All required checks passing
- [ ] Build succeeds
- [ ] Type check passes
- [ ] Lint passes
- [ ] Guardrails pass

## Impact

**Breaking Changes:**
- [ ] No breaking changes
- [ ] Breaking changes (documented below)

**Performance:**
- [ ] No performance impact
- [ ] Performance impact (documented below)

**Security:**
- [ ] No security implications
- [ ] Security review required (documented below)

## Documentation

- [ ] Code comments updated
- [ ] README updated (if needed)
- [ ] Tracker updated (if Phase 6+ work)
- [ ] API documentation updated (if needed)

## Checklist

- [ ] Code follows project standards
- [ ] No `console.log` statements (except in tests)
- [ ] No `any` types (except where explicitly allowed)
- [ ] Design tokens used (no hardcoded values)
- [ ] No inline styles
- [ ] TypeScript strict mode passes
- [ ] ESLint passes
- [ ] All tests pass
- [ ] PR description is complete
- [ ] Ready for review

---

**Auto-merge:** Enabled  
**Reviewers:** [Auto-assigned based on CODEOWNERS]  
**Labels:** [Auto-assigned based on changed files]

