### PR TITLE
fix: close analytics-engine TODO gaps (#284), v12.1.21

### DIFF
--- a/docs/_meta/meta-docs-consistency-audit.md
+++ b/docs/_meta/meta-docs-consistency-audit.md
@@ -1,11 +1,11 @@
 # Docs Consistency Audit
 Status: Active
-Last Updated: 2026-07-02T06:24:17.579Z
+Last Updated: 2026-07-07T14:34:22.184Z
 Canonical: Yes
 Owner: Documentation
 
-Package version: 12.1.20
-Current docs scanned: 109
+Package version: 12.1.21
+Current docs scanned: 112
 Failures: 0
 
 ## Result

--- a/docs/_meta/meta-docs-link-check.md
+++ b/docs/_meta/meta-docs-link-check.md
@@ -1,6 +1,6 @@
 # Docs Link Check
 Status: Active
-Last Updated: 2026-07-07T14:19:01Z
+Last Updated: 2026-07-07T14:34:22Z
 Canonical: Yes
 Owner: Documentation
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -4,7 +4,7 @@ Last Updated: 2026-06-25
 Canonical: No
 Owner: Architecture
 
-Version: 12.1.20
+Version: 12.1.21
 
 **Mantine Entity, Variant, and Public Report Shell Delivery (2026-06-25):**
 - **Report variant selector recovery:** Mantine `Select` dropdowns inside report variant `FormModal` now render through a portal with modal-safe z-index, preventing the dropdown from being hidden behind or interpreted as outside the dialog.
@@ -4548,5 +4548,5 @@ When working with the hashtag categories system:
 ---
 
 *Last Updated: 2025-10-19T11:58:43.000Z*
-*Version: 12.1.20*
+*Version: 12.1.21*
 *Status: Production-Ready — Enterprise Event Analytics Platform with Advanced Analytics Infrastructure*

--- a/docs/components/components-reusable-components-inventory.md
+++ b/docs/components/components-reusable-components-inventory.md
@@ -4,7 +4,7 @@ Last Updated: 2026-04-24
 Canonical: No
 Owner: Architecture
 
-**Version**: 12.1.20
+**Version**: 12.1.21
 **Last Updated**: 2026-04-24 (UTC)
 **Purpose**: Complete catalog of all reusable components, modules, styling systems, and utilities
 
@@ -561,4 +561,4 @@ For implementation details, see:
 
 ---
 
-*Version: 12.1.20 | Last Updated: 2026-06-26 (UTC)*
+*Version: 12.1.21 | Last Updated: 2026-06-26 (UTC)*

--- a/docs/components/components-unified-input-system.md
+++ b/docs/components/components-unified-input-system.md
@@ -4,7 +4,7 @@ Last Updated: 2026-01-11T22:28:38.000Z
 Canonical: No
 Owner: Architecture
 
-**Version**: 12.1.20
+**Version**: 12.1.21
 **Last Updated**: 2026-01-11T22:28:38.000Z
 **Status**: Production-Ready
 

--- a/docs/design/design-system.md
+++ b/docs/design/design-system.md
@@ -4,7 +4,7 @@ Last Updated: 2026-06-26T10:00:00.000Z
 Canonical: Yes
 Owner: Architecture
 
-**Version**: 12.1.20
+**Version**: 12.1.21
 **Status**: Production
 
 ## Purpose

--- a/docs/guides/guides-form-input-migration-guide.md
+++ b/docs/guides/guides-form-input-migration-guide.md
@@ -4,7 +4,7 @@ Last Updated: 2026-01-11T22:28:38.000Z
 Canonical: No
 Owner: Product
 
-**Version**: 12.1.20
+**Version**: 12.1.21
 **Last Updated**: 2026-01-11T22:28:38.000Z
 **Purpose**: Prevent aggressive parsing anti-patterns in future forms
 

--- a/docs/guides/guides-input-system-complete.md
+++ b/docs/guides/guides-input-system-complete.md
@@ -5,7 +5,7 @@ Canonical: No
 Owner: Product
 
 **Date**: 2025-12-25T20:50:00.000Z
-**Version**: 12.1.20
+**Version**: 12.1.21
 **Status**: ✅ Complete - Production Ready
 
 ## 📋 Overview

--- a/docs/low-level-design.md
+++ b/docs/low-level-design.md
@@ -4,7 +4,7 @@ Last Updated: 2026-06-25T00:00:00.000Z
 Canonical: No
 Owner: Architecture
 
-Version: 12.1.20
+Version: 12.1.21
 
 This document captures implementation-level contracts for recently changed high-risk flows. It complements `docs/architecture.md`; it does not replace feature specs or API references.
 

--- a/docs/operations/operations-release-notes.md
+++ b/docs/operations/operations-release-notes.md
@@ -1,8 +1,31 @@
 # {messmass} Release Notes
 Status: Active
-Last Updated: 2026-07-02T06:23:29.000Z
+Last Updated: 2026-07-07T14:33:08.000Z
 Canonical: No
 Owner: Operations
+
+## [v12.1.21] — 2026-07-07T14:33:08.000Z
+
+### Summary
+ANALYTICS TODO GAPS (#284): Closed the remaining analytics-engine stubs so computed metrics stop silently returning placeholder values. Two of the six markers (`overallScore`, editor `contentMetadata`) were already resolved by the 2026-07-05 notification/analytics merge; this release closes the other four and removes every TODO marker from the four tracked files.
+
+### What Was Delivered
+
+#### `costPerEngagement` → honest null instead of 0
+**WHAT**: `lib/analyticsCalculator.ts` returns `null` (not `0`); `AdMetrics.costPerEngagement` typed `number | null` in `lib/analytics.types.ts`.
+**WHY**: `0` reads as a legitimate "free" value to anomaly detection; `null` truthfully signals "unavailable" until an ad-spend data source exists.
+
+#### `hourlyPattern` documented unavailable
+**WHAT**: The `undefined` hourlyPattern in `calculateBitlyMetrics` is now commented as unavailable (the Bitly source has no hourly breakdown); the optional field stays absent rather than faked.
+
+#### `isProjectAggregatable` typed
+**WHAT**: Replaced `project: any` with `Partial<AnalyticsProjectInput>` in `lib/analyticsCalculator.ts`.
+
+#### `detectSeasonalAnomalies` explicitly descoped
+**WHAT**: `lib/analytics-anomaly.ts` — the STL/moving-average TODO is replaced with an explicit descope comment. The function has zero callers; it delegates to standard (non-seasonal) detection and will be wired + implemented under #233 when a caller needs seasonal baselines.
+
+### Testing
+- `npm run type-check`, `npm run lint`, `npm test` (295 passing), `npm run style:check`, `npm run version:verify`, `npm run docs:audit`, `npm run build`
 
 ## [v12.1.20] — 2026-07-02T06:23:29.000Z
 

--- a/lib/analytics-anomaly.ts
+++ b/lib/analytics-anomaly.ts
@@ -389,8 +389,9 @@ export async function detectSeasonalAnomalies(
   seasonality: 'weekly' | 'monthly' | 'quarterly',
   options: AnomalyDetectionOptions = {}
 ): Promise<AnomalyDetectionResult> {
-  // WHAT: For now, delegate to standard anomaly detection
-  // WHY: Full seasonal decomposition requires more complex time-series analysis
-  // TODO: Implement seasonal decomposition (STL decomposition or moving averages)
+  // ponytail: descoped — seasonal decomposition (STL / moving-average) is intentionally NOT implemented.
+  // This function has no callers yet; building STL for a dead path is unused complexity. It delegates to
+  // standard (non-seasonal) detection so the `seasonality` argument is currently ignored. Wire + implement
+  // under #233 (anomaly/trend detection) when a caller actually needs seasonal baselines.
   return detectAnomalies(metric, data, options);
 }

--- a/lib/analytics.types.ts
+++ b/lib/analytics.types.ts
@@ -74,7 +74,7 @@ export interface AdMetrics {
   totalROI: number;                     // socialValue + emailValue
   viralCoefficient: number;             // shares / images × 100
   emailConversion: number;              // purchases / propositionVisits × 100
-  costPerEngagement: number;            // ad spend / total engagements (if available)
+  costPerEngagement: number | null;     // ad spend / total engagements; null = unavailable (no ad-spend data source)
   adValuePerFan: number;                // totalROI / totalFans (unit economics)
   reachMultiplier: number;              // organic reach vs. paid (if applicable)
 }

--- a/lib/analyticsCalculator.ts
+++ b/lib/analyticsCalculator.ts
@@ -248,8 +248,9 @@ export function calculateAdMetrics(stats: ProjectStats, fanMetrics: FanMetrics):
   // Email conversion: Purchases / visits × 100
   const emailConversion = safeDivide(propositionPurchases, propositionVisits) * 100;
   
-  // Cost per engagement: Would need ad spend data (placeholder calculation)
-  const costPerEngagement = 0; // TODO: Implement when ad spend data available
+  // Cost per engagement: requires ad-spend data we don't ingest yet.
+  // ponytail: null = unavailable, not 0 (0 reads as "free" to anomaly detection). Compute when an ad-spend source lands.
+  const costPerEngagement = null;
   
   // Ad value per fan: Total ROI / total fans (unit economics)
   const adValuePerFan = safeDivide(totalROI, totalFans);
@@ -366,7 +367,7 @@ export function calculateBitlyMetrics(stats: ProjectStats): BitlyMetrics | undef
     topCountry: stats.bitlyTopCountry || '',
     referrers: stats.bitlyReferrers || {},
     topReferrer: stats.bitlyTopReferrer || '',
-    hourlyPattern: undefined, // TODO: Implement when hourly data available
+    hourlyPattern: undefined, // unavailable: Bitly source provides no hourly breakdown (optional field = absent)
     clickRate: safeDivide(totalClicks, eventAttendees) * 100,
     mobileRate: safeDivide(mobile, totalClicks) * 100,
   };
@@ -483,7 +484,7 @@ export function aggregateEventMetrics(
  * WHAT: Validate project has minimum required data for aggregation
  * WHY: Skip projects with incomplete data to avoid invalid aggregates
  */
-export function isProjectAggregatable(project: any): boolean {
+export function isProjectAggregatable(project: Partial<AnalyticsProjectInput> | null | undefined): boolean {
   if (!project || !project.stats) return false;
   
   const stats = project.stats;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "messmass",
-  "version": "12.1.20",
+  "version": "12.1.21",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "messmass",
-      "version": "12.1.20",
+      "version": "12.1.21",
       "license": "MIT",
       "dependencies": {
         "@mantine/core": "^8.3.18",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "messmass",
-  "version": "12.1.20",
+  "version": "12.1.21",
   "description": "Enterprise-grade event analytics platform with comprehensive partner management, intelligent link tracking, automated event creation (Sports Match Builder), and advanced real-time statistics dashboard for sports organizations, venues, brands, and event managers",
   "keywords": [
     "event-statistics",
@@ -135,14 +135,14 @@
     "ops:partner-report:logs:fail": "node scripts/auditPartnerReportLogs.mjs --fail-on-errors"
   },
   "dependencies": {
-    "@sovereignsquad/gds-admin": "^3.9.0",
-    "@sovereignsquad/gds-core": "^3.9.0",
-    "@sovereignsquad/gds-theme": "^3.9.0",
     "@mantine/core": "^8.3.18",
     "@mantine/form": "^8.3.18",
     "@mantine/hooks": "^8.3.18",
     "@mantine/modals": "^8.3.18",
     "@mantine/notifications": "^8.3.18",
+    "@sovereignsquad/gds-admin": "^3.9.0",
+    "@sovereignsquad/gds-core": "^3.9.0",
+    "@sovereignsquad/gds-theme": "^3.9.0",
     "@tabler/icons-react": "^3.44.0",
     "bcryptjs": "^3.0.3",
     "chart.js": "^4.5.1",


### PR DESCRIPTION
Closes #284.

Resolves the remaining analytics-engine stubs so computed metrics stop silently returning placeholder values.

## Changes
- **`costPerEngagement`** → returns `null` (typed `number | null`) instead of `0`. `0` reads as a real "free" value to anomaly detection; `null` = unavailable until an ad-spend source exists.
- **`hourlyPattern`** → documented unavailable (Bitly source has no hourly breakdown); optional field stays absent, not faked.
- **`isProjectAggregatable(project: any)`** → typed `Partial<AnalyticsProjectInput>`.
- **`detectSeasonalAnomalies`** → explicitly descoped (zero callers) rather than a rotting TODO; delegates to standard detection, to be wired under #233.

`overallScore` (insightsEngine) and `editorBlockValidator` contentMetadata were already resolved by the 2026-07-05 merge — verified, not re-done here.

## DoD (#284)
- [x] No `any`-typed project parameters in analyticsCalculator
- [x] `overallScore` derives from benchmarks (already shipped)
- [x] `editorBlockValidator` builds contentMetadata from real chart data (already shipped)
- [x] Placeholder metrics compute real values or are explicitly marked unavailable in output types
- [x] TODO markers removed from the four files

## Verification
- `tsc --noEmit` — clean
- `jest` — 30 suites, 295 tests pass
- `style:check` — pass · `eslint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)