### PR TITLE
fix: Reports as singular primary list-view action for partners (#252), v12.1.22

### DIFF
--- a/docs/_meta/meta-docs-consistency-audit.md
+++ b/docs/_meta/meta-docs-consistency-audit.md
@@ -1,11 +1,11 @@
 # Docs Consistency Audit
 Status: Active
-Last Updated: 2026-07-02T06:24:17.579Z
+Last Updated: 2026-07-07T14:52:52.983Z
 Canonical: Yes
 Owner: Documentation
 
-Package version: 12.1.20
-Current docs scanned: 109
+Package version: 12.1.22
+Current docs scanned: 112
 Failures: 0
 
 ## Result

--- a/docs/_meta/meta-docs-link-check.md
+++ b/docs/_meta/meta-docs-link-check.md
@@ -1,6 +1,6 @@
 # Docs Link Check
 Status: Active
-Last Updated: 2026-07-07T14:19:01Z
+Last Updated: 2026-07-07T14:52:53Z
 Canonical: Yes
 Owner: Documentation
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -4,7 +4,7 @@ Last Updated: 2026-06-25
 Canonical: No
 Owner: Architecture
 
-Version: 12.1.20
+Version: 12.1.22
 
 **Mantine Entity, Variant, and Public Report Shell Delivery (2026-06-25):**
 - **Report variant selector recovery:** Mantine `Select` dropdowns inside report variant `FormModal` now render through a portal with modal-safe z-index, preventing the dropdown from being hidden behind or interpreted as outside the dialog.
@@ -4548,5 +4548,5 @@ When working with the hashtag categories system:
 ---
 
 *Last Updated: 2025-10-19T11:58:43.000Z*
-*Version: 12.1.20*
+*Version: 12.1.22*
 *Status: Production-Ready — Enterprise Event Analytics Platform with Advanced Analytics Infrastructure*

--- a/docs/components/components-reusable-components-inventory.md
+++ b/docs/components/components-reusable-components-inventory.md
@@ -4,7 +4,7 @@ Last Updated: 2026-04-24
 Canonical: No
 Owner: Architecture
 
-**Version**: 12.1.20
+**Version**: 12.1.22
 **Last Updated**: 2026-04-24 (UTC)
 **Purpose**: Complete catalog of all reusable components, modules, styling systems, and utilities
 
@@ -561,4 +561,4 @@ For implementation details, see:
 
 ---
 
-*Version: 12.1.20 | Last Updated: 2026-06-26 (UTC)*
+*Version: 12.1.22 | Last Updated: 2026-06-26 (UTC)*

--- a/docs/components/components-unified-input-system.md
+++ b/docs/components/components-unified-input-system.md
@@ -4,7 +4,7 @@ Last Updated: 2026-01-11T22:28:38.000Z
 Canonical: No
 Owner: Architecture
 
-**Version**: 12.1.20
+**Version**: 12.1.22
 **Last Updated**: 2026-01-11T22:28:38.000Z
 **Status**: Production-Ready
 

--- a/docs/design/design-system.md
+++ b/docs/design/design-system.md
@@ -4,7 +4,7 @@ Last Updated: 2026-06-26T10:00:00.000Z
 Canonical: Yes
 Owner: Architecture
 
-**Version**: 12.1.20
+**Version**: 12.1.22
 **Status**: Production
 
 ## Purpose

--- a/docs/guides/guides-form-input-migration-guide.md
+++ b/docs/guides/guides-form-input-migration-guide.md
@@ -4,7 +4,7 @@ Last Updated: 2026-01-11T22:28:38.000Z
 Canonical: No
 Owner: Product
 
-**Version**: 12.1.20
+**Version**: 12.1.22
 **Last Updated**: 2026-01-11T22:28:38.000Z
 **Purpose**: Prevent aggressive parsing anti-patterns in future forms
 

--- a/docs/guides/guides-input-system-complete.md
+++ b/docs/guides/guides-input-system-complete.md
@@ -5,7 +5,7 @@ Canonical: No
 Owner: Product
 
 **Date**: 2025-12-25T20:50:00.000Z
-**Version**: 12.1.20
+**Version**: 12.1.22
 **Status**: ✅ Complete - Production Ready
 
 ## 📋 Overview

--- a/docs/low-level-design.md
+++ b/docs/low-level-design.md
@@ -4,7 +4,7 @@ Last Updated: 2026-06-25T00:00:00.000Z
 Canonical: No
 Owner: Architecture
 
-Version: 12.1.20
+Version: 12.1.22
 
 This document captures implementation-level contracts for recently changed high-risk flows. It complements `docs/architecture.md`; it does not replace feature specs or API references.
 

--- a/docs/operations/operations-release-notes.md
+++ b/docs/operations/operations-release-notes.md
@@ -1,8 +1,31 @@
 # {messmass} Release Notes
 Status: Active
-Last Updated: 2026-07-02T06:23:29.000Z
+Last Updated: 2026-07-07T14:52:18.000Z
 Canonical: No
 Owner: Operations
+
+## [v12.1.22] — 2026-07-07T14:52:18.000Z
+
+### Summary
+REPORT VARIANTS LIST-VIEW ALIGNMENT (#252): Made `Reports` the singular primary list-view action for partners, matching the organizations pattern. The substantive Report Variants workspace (open/create/edit/manage variants, with direct report opening preserved) was already shipped for organizations and partners; this closes the last list-view-grammar gap.
+
+### What Was Delivered
+
+#### Partners list: `Reports` is the sole primary action
+**WHAT**: In `lib/adapters/partnersAdapter.tsx`, demoted the `Open Editor` action from `priority: 'primary'` to `'secondary'`.
+**WHY**: The partners list had two competing primary actions (`Reports` and `Open Editor`), diluting the "primary mental model becomes `Reports`" goal (#252 AC#1). Organizations already model this correctly (`Reports` primary; entity edit in overflow).
+**HOW**: One-line priority change. `Open Editor` is **not** removed — `/partner-edit` is partner data-capture with no parity in the reports workspace, and #252 explicitly forbids removing a working shortcut before parity exists. Full removal is deferred to a product decision.
+
+### Acceptance (#252)
+- AC#1 primary mental model = `Reports`: satisfied (partners now match organizations)
+- AC#2 open/edit variants from the workspace without list-view editor actions: already shipped (workspace has create/edit/manage)
+- AC#3 existing report access preserved: `Open Editor` retained (secondary), direct report opening preserved
+
+### Note
+Depends on #288 (v12.1.21) merging first; if merge order flips, rebase the version. Visual QA of the partners action rail ordering recommended (admin auth/DB not available in the authoring session).
+
+### Testing
+- `npm run type-check`, `npm run lint`, `npm test` (295 passing incl. `admin-action-rail`, `mobile-admin-action-contract`), `npm run style:check`, `npm run version:verify`, `npm run docs:audit`, `npm run build`
 
 ## [v12.1.20] — 2026-07-02T06:23:29.000Z
 

--- a/lib/adapters/partnersAdapter.tsx
+++ b/lib/adapters/partnersAdapter.tsx
@@ -42,7 +42,10 @@ export const partnersEntityConfig: AdminEntityConfig<PartnerResponse> = {
       mobileLabel: 'Editor',
       icon: 'bar_chart',
       variant: 'secondary',
-      priority: 'primary',
+      // ponytail: demoted primary→secondary so `Reports` is the singular primary entry (#252 AC#1),
+      // matching the organizations pattern. NOT deleted — `/partner-edit` is partner data-capture with no
+      // parity in the reports workspace; removal awaits product confirmation of that parity.
+      priority: 'secondary',
       requiredCapabilities: ['edit-content'],
       requiredPermissions: ['admin'],
       execution: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "messmass",
-  "version": "12.1.20",
+  "version": "12.1.22",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "messmass",
-      "version": "12.1.20",
+      "version": "12.1.22",
       "license": "MIT",
       "dependencies": {
         "@mantine/core": "^8.3.18",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "messmass",
-  "version": "12.1.20",
+  "version": "12.1.22",
   "description": "Enterprise-grade event analytics platform with comprehensive partner management, intelligent link tracking, automated event creation (Sports Match Builder), and advanced real-time statistics dashboard for sports organizations, venues, brands, and event managers",
   "keywords": [
     "event-statistics",
@@ -135,14 +135,14 @@
     "ops:partner-report:logs:fail": "node scripts/auditPartnerReportLogs.mjs --fail-on-errors"
   },
   "dependencies": {
-    "@sovereignsquad/gds-admin": "^3.9.0",
-    "@sovereignsquad/gds-core": "^3.9.0",
-    "@sovereignsquad/gds-theme": "^3.9.0",
     "@mantine/core": "^8.3.18",
     "@mantine/form": "^8.3.18",
     "@mantine/hooks": "^8.3.18",
     "@mantine/modals": "^8.3.18",
     "@mantine/notifications": "^8.3.18",
+    "@sovereignsquad/gds-admin": "^3.9.0",
+    "@sovereignsquad/gds-core": "^3.9.0",
+    "@sovereignsquad/gds-theme": "^3.9.0",
     "@tabler/icons-react": "^3.44.0",
     "bcryptjs": "^3.0.3",
     "chart.js": "^4.5.1",


### PR DESCRIPTION
Closes #252 (and unblocks umbrella #244's list-view item).

## Finding first
Most of #252 was **already shipped**. Both organizations and partners already have the Report Variants **workspace** as a `Reports` list action (open/create/edit/manage variants; direct report opening preserved). The only remaining list-view-grammar gap was on **partners**, which had *two* competing primary actions.

## Change
- **`lib/adapters/partnersAdapter.tsx`** — demote `Open Editor` from `priority: 'primary'` → `'secondary'`, so `Reports` is the singular primary action, matching the organizations pattern.

`Open Editor` (`/partner-edit`) is **not removed**: it is partner **data-capture**, which the reports workspace does not replace, and #252 explicitly forbids removing a working shortcut before parity exists. Full removal is deferred to a product decision.

## Acceptance (#252)
- [x] AC#1 — primary mental model becomes `Reports` (partners now match organizations)
- [x] AC#2 — operators open/edit variants from the workspace without list-view editor actions (already shipped)
- [x] AC#3 — existing report access preserved (`Open Editor` retained as secondary; direct opening preserved)

## Verification
Full `ci.yml` gate green locally: `type-check`, `lint`, `test` (295, incl. `admin-action-rail` + `mobile-admin-action-contract`), `style:check`, `version:verify`, `docs:audit`, both guardrails, `build`.

⚠️ **Visual QA**: this reorders the partners action rail; admin auth/DB weren't available in the authoring session, so a human should eyeball the partners list action ordering. `'secondary'` is already used by sibling partner actions, so rendering is proven.

⚠️ **Version**: depends on #288 (v12.1.21) merging first; if merge order flips, rebase the version/release-note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)