### PR TITLE
feat: organization scope for analytics insights (#233), v12.1.23

### DIFF
--- a/app/api/analytics/insights/organizations/[orgId]/route.ts
+++ b/app/api/analytics/insights/organizations/[orgId]/route.ts
@@ -1,0 +1,72 @@
+/**
+ * Analytics Insights API - Organization Route
+ *
+ * WHAT: REST API for fetching insights for a specific organization
+ * WHY: Strategic overview of organization performance across member partners (#233 AC#3)
+ *
+ * Endpoint: GET /api/analytics/insights/organizations/[orgId]
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { getAdminUser } from '@/lib/auth';
+import { generateOrganizationInsights } from '@/lib/analytics-insights';
+
+/**
+ * GET /api/analytics/insights/organizations/[orgId]
+ *
+ * WHAT: Fetch organization-level insights across the org's member-partner events
+ * WHY: Adds organization as an insights reporting scope, matching the partner route
+ *
+ * @param orgId - MongoDB ObjectId of the organization
+ * @returns InsightsReport based on the org's latest event
+ */
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ orgId: string }> }
+) {
+  try {
+    // WHAT: Admin authentication required
+    // WHY: Organization insights contain sensitive business data
+    const user = await getAdminUser();
+    if (!user) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const { orgId } = await params;
+
+    // WHAT: Validate orgId format
+    // WHY: Prevent invalid MongoDB queries
+    if (!/^[0-9a-fA-F]{24}$/.test(orgId)) {
+      return NextResponse.json(
+        { error: 'Invalid organization ID format' },
+        { status: 400 }
+      );
+    }
+
+    // WHAT: Generate organization insights
+    // WHY: Analyze organization performance across member partners
+    const insights = await generateOrganizationInsights(orgId);
+
+    return NextResponse.json(insights);
+  } catch (error) {
+    const resolvedParams = await params;
+    console.error(`Error generating organization insights for ${resolvedParams.orgId}:`, error);
+
+    // WHAT: Handle specific error cases
+    // WHY: Provide useful feedback to client
+    if ((error as Error).message.includes('not found') || (error as Error).message.includes('No events')) {
+      return NextResponse.json(
+        { error: 'Organization not found or has no events' },
+        { status: 404 }
+      );
+    }
+
+    return NextResponse.json(
+      {
+        error: 'Failed to generate organization insights',
+        details: (error as Error).message,
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/docs/_meta/meta-docs-consistency-audit.md
+++ b/docs/_meta/meta-docs-consistency-audit.md
@@ -1,11 +1,11 @@
 # Docs Consistency Audit
 Status: Active
-Last Updated: 2026-07-02T06:24:17.579Z
+Last Updated: 2026-07-08T07:08:01.386Z
 Canonical: Yes
 Owner: Documentation
 
-Package version: 12.1.20
-Current docs scanned: 109
+Package version: 12.1.23
+Current docs scanned: 112
 Failures: 0
 
 ## Result

--- a/docs/_meta/meta-docs-link-check.md
+++ b/docs/_meta/meta-docs-link-check.md
@@ -1,6 +1,6 @@
 # Docs Link Check
 Status: Active
-Last Updated: 2026-07-07T14:19:01Z
+Last Updated: 2026-07-08T07:08:01Z
 Canonical: Yes
 Owner: Documentation
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -4,7 +4,7 @@ Last Updated: 2026-06-25
 Canonical: No
 Owner: Architecture
 
-Version: 12.1.20
+Version: 12.1.23
 
 **Mantine Entity, Variant, and Public Report Shell Delivery (2026-06-25):**
 - **Report variant selector recovery:** Mantine `Select` dropdowns inside report variant `FormModal` now render through a portal with modal-safe z-index, preventing the dropdown from being hidden behind or interpreted as outside the dialog.
@@ -4548,5 +4548,5 @@ When working with the hashtag categories system:
 ---
 
 *Last Updated: 2025-10-19T11:58:43.000Z*
-*Version: 12.1.20*
+*Version: 12.1.23*
 *Status: Production-Ready — Enterprise Event Analytics Platform with Advanced Analytics Infrastructure*

--- a/docs/components/components-reusable-components-inventory.md
+++ b/docs/components/components-reusable-components-inventory.md
@@ -4,7 +4,7 @@ Last Updated: 2026-04-24
 Canonical: No
 Owner: Architecture
 
-**Version**: 12.1.20
+**Version**: 12.1.23
 **Last Updated**: 2026-04-24 (UTC)
 **Purpose**: Complete catalog of all reusable components, modules, styling systems, and utilities
 
@@ -561,4 +561,4 @@ For implementation details, see:
 
 ---
 
-*Version: 12.1.20 | Last Updated: 2026-06-26 (UTC)*
+*Version: 12.1.23 | Last Updated: 2026-06-26 (UTC)*

--- a/docs/components/components-unified-input-system.md
+++ b/docs/components/components-unified-input-system.md
@@ -4,7 +4,7 @@ Last Updated: 2026-01-11T22:28:38.000Z
 Canonical: No
 Owner: Architecture
 
-**Version**: 12.1.20
+**Version**: 12.1.23
 **Last Updated**: 2026-01-11T22:28:38.000Z
 **Status**: Production-Ready
 

--- a/docs/design/design-system.md
+++ b/docs/design/design-system.md
@@ -4,7 +4,7 @@ Last Updated: 2026-06-26T10:00:00.000Z
 Canonical: Yes
 Owner: Architecture
 
-**Version**: 12.1.20
+**Version**: 12.1.23
 **Status**: Production
 
 ## Purpose

--- a/docs/guides/guides-form-input-migration-guide.md
+++ b/docs/guides/guides-form-input-migration-guide.md
@@ -4,7 +4,7 @@ Last Updated: 2026-01-11T22:28:38.000Z
 Canonical: No
 Owner: Product
 
-**Version**: 12.1.20
+**Version**: 12.1.23
 **Last Updated**: 2026-01-11T22:28:38.000Z
 **Purpose**: Prevent aggressive parsing anti-patterns in future forms
 

--- a/docs/guides/guides-input-system-complete.md
+++ b/docs/guides/guides-input-system-complete.md
@@ -5,7 +5,7 @@ Canonical: No
 Owner: Product
 
 **Date**: 2025-12-25T20:50:00.000Z
-**Version**: 12.1.20
+**Version**: 12.1.23
 **Status**: ✅ Complete - Production Ready
 
 ## 📋 Overview

--- a/docs/low-level-design.md
+++ b/docs/low-level-design.md
@@ -4,7 +4,7 @@ Last Updated: 2026-06-25T00:00:00.000Z
 Canonical: No
 Owner: Architecture
 
-Version: 12.1.20
+Version: 12.1.23
 
 This document captures implementation-level contracts for recently changed high-risk flows. It complements `docs/architecture.md`; it does not replace feature specs or API references.
 

--- a/docs/operations/operations-release-notes.md
+++ b/docs/operations/operations-release-notes.md
@@ -1,8 +1,26 @@
 # {messmass} Release Notes
 Status: Active
-Last Updated: 2026-07-02T06:23:29.000Z
+Last Updated: 2026-07-08T07:07:41.000Z
 Canonical: No
 Owner: Operations
+
+## [v12.1.23] — 2026-07-08T07:07:41.000Z
+
+### Summary
+ORGANIZATION INSIGHTS SCOPE (#233): Added organization as a reporting scope to the analytics insights engine, giving parity with the existing event and partner scopes (#233 AC#3). The anomaly/trend/benchmark/prediction insight engines were already live for event and partner scopes; this closes the org-scope gap.
+
+### What Was Delivered
+
+#### `generateOrganizationInsights` + org insights route
+**WHAT**: New `generateOrganizationInsights(organizationId)` in `lib/analytics-insights.ts`, plus `GET /api/analytics/insights/organizations/[orgId]`.
+**WHY**: The insights engine already served event (`generateInsights`) and partner (`generatePartnerInsights`) scopes; #233 AC#3 requires organization scope.
+**HOW**: Mirrors the partner path — resolves the org's member partners (`partner.organizationId`), then their events via the same `partner1/partner2/partner1Id/partner2Id` linkage `app/api/organizations/report/[id]` uses, and generates insights for the most recent event. Fail-proof: returns `null` (not an error) when the org has no member partners, no events, or insufficient data. The route mirrors the partner route's auth + ObjectId validation + error handling.
+
+### Note
+No DB-integration unit test added — consistent with the existing `generatePartnerInsights` (these functions require a live Mongo connection; the repo's test suite is DB-free). Verified by `tsc` + `next build`; the mirrored partner path is exercised in production.
+
+### Testing
+- `npm run type-check`, `npm run lint`, `npm test` (295 passing), `npm run style:check`, `npm run version:verify`, `npm run docs:audit`, both guardrails, `npm run build`
 
 ## [v12.1.20] — 2026-07-02T06:23:29.000Z
 

--- a/lib/analytics-insights.ts
+++ b/lib/analytics-insights.ts
@@ -603,6 +603,64 @@ export async function generatePartnerInsights(partnerId: string): Promise<Insigh
     console.warn(`Partner ${partnerId} latest event has insufficient data for insights`);
     return null;
   }
-  
+
+  return insights;
+}
+
+/**
+ * WHAT: Generate insights for an organization across its member partners' events
+ * WHY: Adds organization as a reporting scope for the insights engine (#233 AC#3),
+ *      giving parity with the event and partner scopes.
+ *
+ * Organizations aggregate events via partner membership (partner.organizationId),
+ * and projects link to partners through partner1/partner2/partner1Id/partner2Id —
+ * mirroring how app/api/organizations/report/[id] resolves an org's events.
+ */
+export async function generateOrganizationInsights(organizationId: string): Promise<InsightsReport | null> {
+  const client = await clientPromise;
+  const db = client.db(config.dbName);
+
+  // WHAT: Resolve the org's member partners first
+  // WHY: Events belong to partners; an org's dataset is the union of its members' events
+  const memberPartners = await db
+    .collection('partners')
+    .find({ organizationId: new ObjectId(organizationId) })
+    .project({ _id: 1 })
+    .toArray();
+
+  const partnerIds = memberPartners.map((partner) => partner._id);
+  if (partnerIds.length === 0) {
+    console.warn(`No member partners for organization ${organizationId}`);
+    return null;
+  }
+
+  // WHAT: Fetch the org's events (across all member partners), newest first
+  // WHY: Same $or partner linkage the org report uses, so scopes stay consistent
+  const orgEvents = await db
+    .collection('projects')
+    .find({
+      $or: [
+        { partner1: { $in: partnerIds } },
+        { partner2: { $in: partnerIds } },
+        { partner1Id: { $in: partnerIds } },
+        { partner2Id: { $in: partnerIds } },
+      ],
+    })
+    .sort({ eventDate: -1 })
+    .toArray();
+
+  if (orgEvents.length === 0) {
+    console.warn(`No events found for organization ${organizationId}`);
+    return null;
+  }
+
+  // WHAT: Insights for the most recent event across member partners
+  // WHY: Mirrors generatePartnerInsights (representative latest-event sample)
+  const insights = await generateInsights(orgEvents[0]._id.toString());
+  if (!insights) {
+    console.warn(`Organization ${organizationId} latest event has insufficient data for insights`);
+    return null;
+  }
+
   return insights;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "messmass",
-  "version": "12.1.20",
+  "version": "12.1.23",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "messmass",
-      "version": "12.1.20",
+      "version": "12.1.23",
       "license": "MIT",
       "dependencies": {
         "@mantine/core": "^8.3.18",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "messmass",
-  "version": "12.1.20",
+  "version": "12.1.23",
   "description": "Enterprise-grade event analytics platform with comprehensive partner management, intelligent link tracking, automated event creation (Sports Match Builder), and advanced real-time statistics dashboard for sports organizations, venues, brands, and event managers",
   "keywords": [
     "event-statistics",
@@ -135,14 +135,14 @@
     "ops:partner-report:logs:fail": "node scripts/auditPartnerReportLogs.mjs --fail-on-errors"
   },
   "dependencies": {
-    "@sovereignsquad/gds-admin": "^3.9.0",
-    "@sovereignsquad/gds-core": "^3.9.0",
-    "@sovereignsquad/gds-theme": "^3.9.0",
     "@mantine/core": "^8.3.18",
     "@mantine/form": "^8.3.18",
     "@mantine/hooks": "^8.3.18",
     "@mantine/modals": "^8.3.18",
     "@mantine/notifications": "^8.3.18",
+    "@sovereignsquad/gds-admin": "^3.9.0",
+    "@sovereignsquad/gds-core": "^3.9.0",
+    "@sovereignsquad/gds-theme": "^3.9.0",
     "@tabler/icons-react": "^3.44.0",
     "bcryptjs": "^3.0.3",
     "chart.js": "^4.5.1",


### PR DESCRIPTION
Advances #233 (closes AC#3 — organization reporting scope).

## Context (from audit)
The anomaly/trend/benchmark/prediction insight engines are **already live** for event (`generateInsights`) and partner (`generatePartnerInsights`) scopes, wired into `/admin/analytics/insights`. #233's only unmet acceptance check was **organization** as a second+ scope.

## Change
- **`lib/analytics-insights.ts`** — `generateOrganizationInsights(orgId)`: resolves member partners (`partner.organizationId`) → their events (same `partner1/partner2/partner1Id/partner2Id` linkage as `app/api/organizations/report/[id]`) → insights for the most recent event. Fail-proof `null` returns.
- **`app/api/analytics/insights/organizations/[orgId]/route.ts`** — GET route mirroring the partner route (auth, ObjectId validation, 401/400/404/500 handling).

## Acceptance (#233)
- [x] AC#1 detects anomalies/trends — already live
- [x] AC#2 grouped w/ severity — already live
- [x] **AC#3 more than one scope incl. organization** — this PR (event + partner + **organization**)
- [x] AC#4 info/warning/critical — already live

## Verification
Full `ci.yml` gate green locally: `type-check`, `lint`, `test` (295), `style:check`, `version:verify`, `docs:audit`, both guardrails, `build`.

⚠️ No DB-integration test — consistent with the existing untested-in-unit `generatePartnerInsights` (needs live Mongo; repo tests are DB-free). Mirrored partner path is exercised in production.
⚠️ Version depends on #288 + #289 merging first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)