### PR TITLE
feat: report content slot gap detection (#125), v12.1.24

### DIFF
--- a/components/ReportContentManager.tsx
+++ b/components/ReportContentManager.tsx
@@ -9,6 +9,7 @@ import React, { useMemo, useRef, useState } from 'react';
 import Image from 'next/image';
 import { apiPost } from '@/lib/apiClient';
 import { uploadImageToImgbb } from '@/lib/imgbbClientUpload';
+import { findSlotHoles } from '@/lib/reportContentSlots';
 import styles from './ReportContentManager.module.css';
 
 interface ReportContentManagerProps {
@@ -95,6 +96,12 @@ export default function ReportContentManager({ stats, onCommit, maxSlots = 500 }
 
   const occupiedImages = useMemo(() => getOccupied(stats, 'reportImage', maxSlots), [stats, maxSlots]);
   const occupiedTexts = useMemo(() => getOccupied(stats, 'reportText', maxSlots), [stats, maxSlots]);
+
+  // WHAT: Detect gaps in the occupied slot sequences
+  // WHY: Holes misalign auto-generated chart blocks; surfacing the gap indices lets
+  //      operators Compact (re-number) before the report renders. See #125.
+  const imageHoles = useMemo(() => findSlotHoles(occupiedImages), [occupiedImages]);
+  const textHoles = useMemo(() => findSlotHoles(occupiedTexts), [occupiedTexts]);
 
   // ACTION: Bulk upload images → assign to next free slots
   const handleBulkUpload = async (files: FileList | null) => {
@@ -248,6 +255,13 @@ export default function ReportContentManager({ stats, onCommit, maxSlots = 500 }
         <div className={styles.note}>
           {busy ? 'Processing…' : error ? `⚠️ ${error}` : 'Manage unlimited slots. Deleting keeps holes; use Compact to re-number.'}
         </div>
+        {(imageHoles.length > 0 || textHoles.length > 0) && (
+          <div className={styles.note}>
+            ⚠️ Slot gaps detected — chart blocks may misalign; use Compact to re-number.
+            {imageHoles.length > 0 && ` Images: ${imageHoles.map((h) => `#${h}`).join(', ')}.`}
+            {textHoles.length > 0 && ` Texts: ${textHoles.map((h) => `#${h}`).join(', ')}.`}
+          </div>
+        )}
       </div>
 
       {/* Images Section */}

--- a/docs/_meta/meta-docs-consistency-audit.md
+++ b/docs/_meta/meta-docs-consistency-audit.md
@@ -1,11 +1,11 @@
 # Docs Consistency Audit
 Status: Active
-Last Updated: 2026-07-02T06:24:17.579Z
+Last Updated: 2026-07-08T07:12:29.351Z
 Canonical: Yes
 Owner: Documentation
 
-Package version: 12.1.20
-Current docs scanned: 109
+Package version: 12.1.24
+Current docs scanned: 112
 Failures: 0
 
 ## Result

--- a/docs/_meta/meta-docs-link-check.md
+++ b/docs/_meta/meta-docs-link-check.md
@@ -1,6 +1,6 @@
 # Docs Link Check
 Status: Active
-Last Updated: 2026-07-07T14:19:01Z
+Last Updated: 2026-07-08T07:12:29Z
 Canonical: Yes
 Owner: Documentation
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -4,7 +4,7 @@ Last Updated: 2026-06-25
 Canonical: No
 Owner: Architecture
 
-Version: 12.1.20
+Version: 12.1.24
 
 **Mantine Entity, Variant, and Public Report Shell Delivery (2026-06-25):**
 - **Report variant selector recovery:** Mantine `Select` dropdowns inside report variant `FormModal` now render through a portal with modal-safe z-index, preventing the dropdown from being hidden behind or interpreted as outside the dialog.
@@ -4548,5 +4548,5 @@ When working with the hashtag categories system:
 ---
 
 *Last Updated: 2025-10-19T11:58:43.000Z*
-*Version: 12.1.20*
+*Version: 12.1.24*
 *Status: Production-Ready — Enterprise Event Analytics Platform with Advanced Analytics Infrastructure*

--- a/docs/components/components-reusable-components-inventory.md
+++ b/docs/components/components-reusable-components-inventory.md
@@ -4,7 +4,7 @@ Last Updated: 2026-04-24
 Canonical: No
 Owner: Architecture
 
-**Version**: 12.1.20
+**Version**: 12.1.24
 **Last Updated**: 2026-04-24 (UTC)
 **Purpose**: Complete catalog of all reusable components, modules, styling systems, and utilities
 
@@ -561,4 +561,4 @@ For implementation details, see:
 
 ---
 
-*Version: 12.1.20 | Last Updated: 2026-06-26 (UTC)*
+*Version: 12.1.24 | Last Updated: 2026-06-26 (UTC)*

--- a/docs/components/components-unified-input-system.md
+++ b/docs/components/components-unified-input-system.md
@@ -4,7 +4,7 @@ Last Updated: 2026-01-11T22:28:38.000Z
 Canonical: No
 Owner: Architecture
 
-**Version**: 12.1.20
+**Version**: 12.1.24
 **Last Updated**: 2026-01-11T22:28:38.000Z
 **Status**: Production-Ready
 

--- a/docs/design/design-system.md
+++ b/docs/design/design-system.md
@@ -4,7 +4,7 @@ Last Updated: 2026-06-26T10:00:00.000Z
 Canonical: Yes
 Owner: Architecture
 
-**Version**: 12.1.20
+**Version**: 12.1.24
 **Status**: Production
 
 ## Purpose

--- a/docs/guides/guides-form-input-migration-guide.md
+++ b/docs/guides/guides-form-input-migration-guide.md
@@ -4,7 +4,7 @@ Last Updated: 2026-01-11T22:28:38.000Z
 Canonical: No
 Owner: Product
 
-**Version**: 12.1.20
+**Version**: 12.1.24
 **Last Updated**: 2026-01-11T22:28:38.000Z
 **Purpose**: Prevent aggressive parsing anti-patterns in future forms
 

--- a/docs/guides/guides-input-system-complete.md
+++ b/docs/guides/guides-input-system-complete.md
@@ -5,7 +5,7 @@ Canonical: No
 Owner: Product
 
 **Date**: 2025-12-25T20:50:00.000Z
-**Version**: 12.1.20
+**Version**: 12.1.24
 **Status**: ✅ Complete - Production Ready
 
 ## 📋 Overview

--- a/docs/low-level-design.md
+++ b/docs/low-level-design.md
@@ -4,7 +4,7 @@ Last Updated: 2026-06-25T00:00:00.000Z
 Canonical: No
 Owner: Architecture
 
-Version: 12.1.20
+Version: 12.1.24
 
 This document captures implementation-level contracts for recently changed high-risk flows. It complements `docs/architecture.md`; it does not replace feature specs or API references.
 

--- a/docs/operations/operations-release-notes.md
+++ b/docs/operations/operations-release-notes.md
@@ -1,8 +1,26 @@
 # {messmass} Release Notes
 Status: Active
-Last Updated: 2026-07-02T06:23:29.000Z
+Last Updated: 2026-07-08T07:11:54.000Z
 Canonical: No
 Owner: Operations
+
+## [v12.1.24] — 2026-07-08T07:11:54.000Z
+
+### Summary
+REPORT CONTENT SLOT GAP DETECTION (#125): Surface gaps ("holes") in the occupied report-content slot sequences so operators can fix chart-block misalignment before a report renders. The slot manager already supported bulk upload/add/swap/compact/auto-chart-generation; this adds the missing validation feedback.
+
+### What Was Delivered
+
+#### Slot gap detection + warning
+**WHAT**: New pure helper `lib/reportContentSlots.ts` `findSlotHoles()`; wired into `components/ReportContentManager.tsx` via two memos (`imageHoles`, `textHoles`) that render a warning listing the gap indices.
+**WHY**: Holes in `reportImageN`/`reportTextN` sequences misalign auto-generated chart blocks (the existing Compact action re-numbers to fix them, but the UI never showed WHERE the gaps were). #125 acceptance-check "preview/validation".
+**HOW**: `findSlotHoles` returns the missing indices between 1 and the highest occupied slot (trailing free slots are not holes). Unit-tested in `tests/report-content-slot-holes.test.ts` (6 cases).
+
+### Testing
+- `npm run type-check`, `npm run lint`, `npm test` (301 passing, +6 new), `npm run style:check`, `npm run version:verify`, `npm run docs:audit`, both guardrails, `npm run build`
+
+### Note
+Depends on #288/#289/#290 merging first; rebase version if order differs. Visual QA of the warning in the Clicker content tab recommended (admin auth/DB not available in the authoring session).
 
 ## [v12.1.20] — 2026-07-02T06:23:29.000Z
 

--- a/lib/reportContentSlots.ts
+++ b/lib/reportContentSlots.ts
@@ -1,0 +1,22 @@
+// WHAT: Pure helpers for report content slot (reportImageN / reportTextN) validation
+// WHY: Holes (gaps) in the occupied slot sequence misalign auto-generated chart blocks
+//      (the Compact action re-numbers to fix them). Surfacing WHERE the gaps are lets
+//      operators fix them before the report renders. Pure + DB-free so it is unit-testable.
+
+/**
+ * WHAT: Find gap indices in an ascending list of occupied slots.
+ * WHY: A "hole" is an empty slot index below the highest occupied one — e.g. slots
+ *      1 and 3 occupied → index 2 is a hole. Trailing free slots are not holes.
+ * @param occupied ascending-by-index occupied slot entries (as returned by getOccupied)
+ * @returns the missing indices between 1 and the highest occupied index
+ */
+export function findSlotHoles(occupied: { index: number }[]): number[] {
+  if (occupied.length === 0) return [];
+  const max = occupied.reduce((m, o) => Math.max(m, o.index), 0);
+  const present = new Set(occupied.map((o) => o.index));
+  const holes: number[] = [];
+  for (let i = 1; i < max; i++) {
+    if (!present.has(i)) holes.push(i);
+  }
+  return holes;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "messmass",
-  "version": "12.1.20",
+  "version": "12.1.24",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "messmass",
-      "version": "12.1.20",
+      "version": "12.1.24",
       "license": "MIT",
       "dependencies": {
         "@mantine/core": "^8.3.18",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "messmass",
-  "version": "12.1.20",
+  "version": "12.1.24",
   "description": "Enterprise-grade event analytics platform with comprehensive partner management, intelligent link tracking, automated event creation (Sports Match Builder), and advanced real-time statistics dashboard for sports organizations, venues, brands, and event managers",
   "keywords": [
     "event-statistics",
@@ -135,14 +135,14 @@
     "ops:partner-report:logs:fail": "node scripts/auditPartnerReportLogs.mjs --fail-on-errors"
   },
   "dependencies": {
-    "@sovereignsquad/gds-admin": "^3.9.0",
-    "@sovereignsquad/gds-core": "^3.9.0",
-    "@sovereignsquad/gds-theme": "^3.9.0",
     "@mantine/core": "^8.3.18",
     "@mantine/form": "^8.3.18",
     "@mantine/hooks": "^8.3.18",
     "@mantine/modals": "^8.3.18",
     "@mantine/notifications": "^8.3.18",
+    "@sovereignsquad/gds-admin": "^3.9.0",
+    "@sovereignsquad/gds-core": "^3.9.0",
+    "@sovereignsquad/gds-theme": "^3.9.0",
     "@tabler/icons-react": "^3.44.0",
     "bcryptjs": "^3.0.3",
     "chart.js": "^4.5.1",

--- a/tests/report-content-slot-holes.test.ts
+++ b/tests/report-content-slot-holes.test.ts
@@ -1,0 +1,33 @@
+import { findSlotHoles } from '@/lib/reportContentSlots';
+
+// WHAT: Verify gap detection in occupied report-content slots (#125)
+// WHY: Holes misalign auto-generated chart blocks; the UI surfaces these indices.
+
+describe('findSlotHoles', () => {
+  const occ = (...indices: number[]) => indices.map((index) => ({ index }));
+
+  it('returns no holes for a contiguous sequence from 1', () => {
+    expect(findSlotHoles(occ(1, 2, 3))).toEqual([]);
+  });
+
+  it('returns no holes for an empty list', () => {
+    expect(findSlotHoles([])).toEqual([]);
+  });
+
+  it('finds a single interior gap', () => {
+    expect(findSlotHoles(occ(1, 3))).toEqual([2]);
+  });
+
+  it('finds multiple gaps and ignores trailing free slots', () => {
+    // occupied 1,4,6 → holes 2,3,5 (nothing above 6 is a hole)
+    expect(findSlotHoles(occ(1, 4, 6))).toEqual([2, 3, 5]);
+  });
+
+  it('reports leading gap when the sequence does not start at 1', () => {
+    expect(findSlotHoles(occ(3))).toEqual([1, 2]);
+  });
+
+  it('is order-independent (max index defines the ceiling)', () => {
+    expect(findSlotHoles(occ(6, 1, 4))).toEqual([2, 3, 5]);
+  });
+});


### PR DESCRIPTION
Advances #125 (adds the slot preview/validation acceptance-check).

## Context (from audit)
`components/ReportContentManager.tsx` already manages `reportImageN`/`reportTextN` slots (bulk upload, add, swap, compact, auto chart-block generation). The gap was **validation feedback** — holes in the slot sequence misalign auto-generated chart blocks, and the Compact action fixes them, but the UI never showed *where* the gaps were.

## Change
- **`lib/reportContentSlots.ts`** — pure `findSlotHoles()` returning missing indices between 1 and the highest occupied slot (trailing free slots are not holes).
- **`components/ReportContentManager.tsx`** — `imageHoles`/`textHoles` memos render a warning listing the gap indices.
- **`tests/report-content-slot-holes.test.ts`** — 6 cases (contiguous, empty, interior gap, multiple gaps + trailing, leading gap, order-independence).

## Verification
Full `ci.yml` gate green locally: `type-check`, `lint`, `test` (301, +6 new), `style:check`, `version:verify`, `docs:audit`, both guardrails, `build`.

⚠️ Visual QA of the warning in the Clicker content tab recommended (admin auth/DB not available in the authoring session).
⚠️ Version depends on #288/#289/#290 merging first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)