### PR TITLE
feat: Bitly analytics CSV export (#131), v12.1.25

### DIFF
--- a/app/admin/bitly/page.tsx
+++ b/app/admin/bitly/page.tsx
@@ -1081,6 +1081,16 @@ export default function BitlyAdminPage() {
                         >
                           ⬇️ Pull
                         </button>
+                        {/* WHAT: Export this link's cached analytics as CSV (#131)
+                         * WHY: Package click/geo/referrer/timeseries evidence for reporting; uses cached data */}
+                        <a
+                          href={`/api/bitly/analytics/${link._id}?format=csv`}
+                          className="btn btn-small btn-secondary action-button"
+                          title="Export this link's analytics as CSV"
+                          download
+                        >
+                          📄 Export
+                        </a>
                         <button
                           onClick={() => handleArchiveLink(link._id)}
                           className="btn btn-small btn-danger action-button"

--- a/app/api/bitly/analytics/[linkId]/route.ts
+++ b/app/api/bitly/analytics/[linkId]/route.ts
@@ -17,6 +17,7 @@ import {
   mergeTimeseries 
 } from '@/lib/bitly-mappers';
 import { error as logError, info as logInfo } from '@/lib/logger';
+import { bitlyLinkToCsv, bitlyExportFilename, type BitlyExportLink } from '@/lib/bitlyExport';
 
 /**
  * GET /api/bitly/analytics/[linkId]
@@ -64,6 +65,7 @@ export async function GET(
     // WHAT: Parse query parameters
     const { searchParams } = new URL(request.url);
     const refresh = searchParams.get('refresh') === 'true';
+    const format = searchParams.get('format');
 
     // WHAT: Fetch link document from database
     const client = await clientPromise;
@@ -141,6 +143,21 @@ export async function GET(
           error: error instanceof Error ? error.message : 'Unknown error',
         });
       }
+    }
+
+    // WHAT: CSV export of cached analytics (#131)
+    // WHY: Package a single link's click/geo/referrer/timeseries breakdown for reporting,
+    //      reusing DB-cached data (no Bitly API call).
+    if (format === 'csv') {
+      const exportLink = link as unknown as BitlyExportLink;
+      const csv = bitlyLinkToCsv(exportLink);
+      return new NextResponse(csv, {
+        status: 200,
+        headers: {
+          'Content-Type': 'text/csv; charset=utf-8',
+          'Content-Disposition': `attachment; filename="${bitlyExportFilename(exportLink)}"`,
+        },
+      });
     }
 
     // WHAT: Return cached analytics data (no refresh requested)

--- a/docs/_meta/meta-docs-consistency-audit.md
+++ b/docs/_meta/meta-docs-consistency-audit.md
@@ -1,11 +1,11 @@
 # Docs Consistency Audit
 Status: Active
-Last Updated: 2026-07-02T06:24:17.579Z
+Last Updated: 2026-07-08T07:17:14.914Z
 Canonical: Yes
 Owner: Documentation
 
-Package version: 12.1.20
-Current docs scanned: 109
+Package version: 12.1.25
+Current docs scanned: 112
 Failures: 0
 
 ## Result

--- a/docs/_meta/meta-docs-link-check.md
+++ b/docs/_meta/meta-docs-link-check.md
@@ -1,6 +1,6 @@
 # Docs Link Check
 Status: Active
-Last Updated: 2026-07-07T14:19:01Z
+Last Updated: 2026-07-08T07:17:14Z
 Canonical: Yes
 Owner: Documentation
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -4,7 +4,7 @@ Last Updated: 2026-06-25
 Canonical: No
 Owner: Architecture
 
-Version: 12.1.20
+Version: 12.1.25
 
 **Mantine Entity, Variant, and Public Report Shell Delivery (2026-06-25):**
 - **Report variant selector recovery:** Mantine `Select` dropdowns inside report variant `FormModal` now render through a portal with modal-safe z-index, preventing the dropdown from being hidden behind or interpreted as outside the dialog.
@@ -4548,5 +4548,5 @@ When working with the hashtag categories system:
 ---
 
 *Last Updated: 2025-10-19T11:58:43.000Z*
-*Version: 12.1.20*
+*Version: 12.1.25*
 *Status: Production-Ready — Enterprise Event Analytics Platform with Advanced Analytics Infrastructure*

--- a/docs/components/components-reusable-components-inventory.md
+++ b/docs/components/components-reusable-components-inventory.md
@@ -4,7 +4,7 @@ Last Updated: 2026-04-24
 Canonical: No
 Owner: Architecture
 
-**Version**: 12.1.20
+**Version**: 12.1.25
 **Last Updated**: 2026-04-24 (UTC)
 **Purpose**: Complete catalog of all reusable components, modules, styling systems, and utilities
 
@@ -561,4 +561,4 @@ For implementation details, see:
 
 ---
 
-*Version: 12.1.20 | Last Updated: 2026-06-26 (UTC)*
+*Version: 12.1.25 | Last Updated: 2026-06-26 (UTC)*

--- a/docs/components/components-unified-input-system.md
+++ b/docs/components/components-unified-input-system.md
@@ -4,7 +4,7 @@ Last Updated: 2026-01-11T22:28:38.000Z
 Canonical: No
 Owner: Architecture
 
-**Version**: 12.1.20
+**Version**: 12.1.25
 **Last Updated**: 2026-01-11T22:28:38.000Z
 **Status**: Production-Ready
 

--- a/docs/design/design-system.md
+++ b/docs/design/design-system.md
@@ -4,7 +4,7 @@ Last Updated: 2026-06-26T10:00:00.000Z
 Canonical: Yes
 Owner: Architecture
 
-**Version**: 12.1.20
+**Version**: 12.1.25
 **Status**: Production
 
 ## Purpose

--- a/docs/guides/guides-form-input-migration-guide.md
+++ b/docs/guides/guides-form-input-migration-guide.md
@@ -4,7 +4,7 @@ Last Updated: 2026-01-11T22:28:38.000Z
 Canonical: No
 Owner: Product
 
-**Version**: 12.1.20
+**Version**: 12.1.25
 **Last Updated**: 2026-01-11T22:28:38.000Z
 **Purpose**: Prevent aggressive parsing anti-patterns in future forms
 

--- a/docs/guides/guides-input-system-complete.md
+++ b/docs/guides/guides-input-system-complete.md
@@ -5,7 +5,7 @@ Canonical: No
 Owner: Product
 
 **Date**: 2025-12-25T20:50:00.000Z
-**Version**: 12.1.20
+**Version**: 12.1.25
 **Status**: ✅ Complete - Production Ready
 
 ## 📋 Overview

--- a/docs/low-level-design.md
+++ b/docs/low-level-design.md
@@ -4,7 +4,7 @@ Last Updated: 2026-06-25T00:00:00.000Z
 Canonical: No
 Owner: Architecture
 
-Version: 12.1.20
+Version: 12.1.25
 
 This document captures implementation-level contracts for recently changed high-risk flows. It complements `docs/architecture.md`; it does not replace feature specs or API references.
 

--- a/docs/operations/operations-release-notes.md
+++ b/docs/operations/operations-release-notes.md
@@ -1,8 +1,26 @@
 # {messmass} Release Notes
 Status: Active
-Last Updated: 2026-07-02T06:23:29.000Z
+Last Updated: 2026-07-08T07:16:48.000Z
 Canonical: No
 Owner: Operations
+
+## [v12.1.25] — 2026-07-08T07:16:48.000Z
+
+### Summary
+BITLY ANALYTICS CSV EXPORT (#131): Add a per-link CSV export so a Bitly link's full click/geo/referrer/timeseries breakdown can be packaged for stakeholder reporting. Reuses DB-cached analytics (no Bitly API call).
+
+### What Was Delivered
+
+#### Bitly link CSV export
+**WHAT**: New pure serializer `lib/bitlyExport.ts` (`bitlyLinkToCsv`, `csvCell`, `bitlyExportFilename`); `?format=csv` on `GET /api/bitly/analytics/[linkId]` returns a sectioned CSV (Summary / Daily Clicks / Countries / Referrers) with `Content-Type: text/csv` + `Content-Disposition`; a `📄 Export` button on each row in `app/admin/bitly/page.tsx`.
+**WHY**: Bitly evidence already rode along in report CSVs, but there was no way to export a single link's full breakdown. #131.
+**HOW**: Export reads the cached `bitly_links` document (no live Bitly call); CSV cells are RFC-4180 escaped. Unit-tested in `tests/bitly-export.test.ts` (8 cases: escaping, filename slugging, section content, missing-section robustness).
+
+### Testing
+- `npm run type-check`, `npm run lint`, `npm test` (303 passing, +8 new), `npm run style:check`, `npm run version:verify`, `npm run docs:audit`, both guardrails, `npm run build`
+
+### Note
+Depends on #288/#289/#290/#291 merging first; rebase version if order differs. Visual QA of the Export button in `/admin/bitly` recommended (admin auth/DB not available in the authoring session).
 
 ## [v12.1.20] — 2026-07-02T06:23:29.000Z
 

--- a/lib/bitlyExport.ts
+++ b/lib/bitlyExport.ts
@@ -1,0 +1,81 @@
+// WHAT: Serialize a Bitly link's cached analytics into a shareable CSV artifact (#131)
+// WHY: Bitly evidence rides along in report CSVs, but there was no way to export a single
+//      link's full click/geo/referrer/timeseries breakdown for stakeholder reporting.
+//      Pure + dependency-free so it is unit-testable and reuses the DB-cached data (no Bitly call).
+
+type ClickSummary = { total?: number; unique?: number };
+type TimeseriesPoint = { date?: string; clicks?: number };
+type CountryPoint = { country?: string; clicks?: number };
+type ReferrerPoint = { referrer?: string; clicks?: number };
+
+export interface BitlyExportLink {
+  bitlink?: string;
+  long_url?: string;
+  title?: string;
+  click_summary?: ClickSummary;
+  clicks_timeseries?: TimeseriesPoint[];
+  geo?: { countries?: CountryPoint[] };
+  referrers?: ReferrerPoint[];
+  lastSyncAt?: string;
+}
+
+/**
+ * WHAT: RFC-4180-style cell escaping.
+ * WHY: Titles/URLs/referrers can contain commas, quotes, or newlines.
+ */
+export function csvCell(value: unknown): string {
+  const s = value === undefined || value === null ? '' : String(value);
+  if (/[",\n\r]/.test(s)) {
+    return `"${s.replace(/"/g, '""')}"`;
+  }
+  return s;
+}
+
+/**
+ * WHAT: Build a sectioned CSV (Summary / Daily Clicks / Countries / Referrers) for one link.
+ * WHY: One file that packages every cached dimension for reuse in reporting.
+ */
+export function bitlyLinkToCsv(link: BitlyExportLink): string {
+  const lines: string[] = [];
+  const row = (...cells: unknown[]) => lines.push(cells.map(csvCell).join(','));
+
+  row('Bitly Link Analytics Export');
+  row('Bitlink', link.bitlink ?? '');
+  row('Title', link.title ?? '');
+  row('Long URL', link.long_url ?? '');
+  row('Total Clicks', link.click_summary?.total ?? 0);
+  row('Unique Clicks', link.click_summary?.unique ?? '');
+  row('Last Sync', link.lastSyncAt ?? '');
+  lines.push('');
+
+  row('Daily Clicks');
+  row('Date', 'Clicks');
+  for (const p of link.clicks_timeseries ?? []) {
+    row(p.date ?? '', p.clicks ?? 0);
+  }
+  lines.push('');
+
+  row('Countries');
+  row('Country', 'Clicks');
+  for (const c of link.geo?.countries ?? []) {
+    row(c.country ?? '', c.clicks ?? 0);
+  }
+  lines.push('');
+
+  row('Referrers');
+  row('Referrer', 'Clicks');
+  for (const r of link.referrers ?? []) {
+    row(r.referrer ?? '', r.clicks ?? 0);
+  }
+
+  return lines.join('\n');
+}
+
+/**
+ * WHAT: Safe download filename for a link's export.
+ * WHY: Bitlinks contain '/'; strip to a filesystem-safe slug.
+ */
+export function bitlyExportFilename(link: BitlyExportLink): string {
+  const slug = (link.bitlink || 'bitly-link').replace(/[^a-zA-Z0-9._-]+/g, '-');
+  return `bitly-${slug}.csv`;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "messmass",
-  "version": "12.1.20",
+  "version": "12.1.25",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "messmass",
-      "version": "12.1.20",
+      "version": "12.1.25",
       "license": "MIT",
       "dependencies": {
         "@mantine/core": "^8.3.18",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "messmass",
-  "version": "12.1.20",
+  "version": "12.1.25",
   "description": "Enterprise-grade event analytics platform with comprehensive partner management, intelligent link tracking, automated event creation (Sports Match Builder), and advanced real-time statistics dashboard for sports organizations, venues, brands, and event managers",
   "keywords": [
     "event-statistics",
@@ -135,14 +135,14 @@
     "ops:partner-report:logs:fail": "node scripts/auditPartnerReportLogs.mjs --fail-on-errors"
   },
   "dependencies": {
-    "@sovereignsquad/gds-admin": "^3.9.0",
-    "@sovereignsquad/gds-core": "^3.9.0",
-    "@sovereignsquad/gds-theme": "^3.9.0",
     "@mantine/core": "^8.3.18",
     "@mantine/form": "^8.3.18",
     "@mantine/hooks": "^8.3.18",
     "@mantine/modals": "^8.3.18",
     "@mantine/notifications": "^8.3.18",
+    "@sovereignsquad/gds-admin": "^3.9.0",
+    "@sovereignsquad/gds-core": "^3.9.0",
+    "@sovereignsquad/gds-theme": "^3.9.0",
     "@tabler/icons-react": "^3.44.0",
     "bcryptjs": "^3.0.3",
     "chart.js": "^4.5.1",

--- a/tests/bitly-export.test.ts
+++ b/tests/bitly-export.test.ts
@@ -1,0 +1,71 @@
+import { bitlyLinkToCsv, csvCell, bitlyExportFilename } from '@/lib/bitlyExport';
+
+// WHAT: Verify Bitly link CSV serialization (#131)
+
+describe('csvCell', () => {
+  it('passes through plain values', () => {
+    expect(csvCell('hello')).toBe('hello');
+    expect(csvCell(42)).toBe('42');
+  });
+  it('renders null/undefined as empty', () => {
+    expect(csvCell(undefined)).toBe('');
+    expect(csvCell(null)).toBe('');
+  });
+  it('quotes and escapes commas, quotes, newlines', () => {
+    expect(csvCell('a,b')).toBe('"a,b"');
+    expect(csvCell('say "hi"')).toBe('"say ""hi"""');
+    expect(csvCell('line1\nline2')).toBe('"line1\nline2"');
+  });
+});
+
+describe('bitlyExportFilename', () => {
+  it('slugifies the bitlink', () => {
+    expect(bitlyExportFilename({ bitlink: 'bit.ly/3fK8Lm2' })).toBe('bitly-bit.ly-3fK8Lm2.csv');
+  });
+  it('falls back when no bitlink', () => {
+    expect(bitlyExportFilename({})).toBe('bitly-bitly-link.csv');
+  });
+});
+
+describe('bitlyLinkToCsv', () => {
+  const link = {
+    bitlink: 'bit.ly/abc',
+    title: 'Campaign, Q3',
+    long_url: 'https://example.com/p',
+    click_summary: { total: 120, unique: 90 },
+    clicks_timeseries: [
+      { date: '2026-07-01', clicks: 10 },
+      { date: '2026-07-02', clicks: 20 },
+    ],
+    geo: { countries: [{ country: 'HU', clicks: 80 }, { country: 'RO', clicks: 40 }] },
+    referrers: [{ referrer: 'instagram', clicks: 70 }],
+    lastSyncAt: '2026-07-07T00:00:00.000Z',
+  };
+
+  it('includes summary, sections, and headers', () => {
+    const csv = bitlyLinkToCsv(link);
+    expect(csv).toContain('Bitlink,bit.ly/abc');
+    expect(csv).toContain('Total Clicks,120');
+    expect(csv).toContain('Unique Clicks,90');
+    expect(csv).toContain('Daily Clicks');
+    expect(csv).toContain('Date,Clicks');
+    expect(csv).toContain('2026-07-01,10');
+    expect(csv).toContain('Countries');
+    expect(csv).toContain('HU,80');
+    expect(csv).toContain('Referrers');
+    expect(csv).toContain('instagram,70');
+  });
+
+  it('escapes commas in the title', () => {
+    expect(bitlyLinkToCsv(link)).toContain('Title,"Campaign, Q3"');
+  });
+
+  it('is robust to missing sections', () => {
+    const csv = bitlyLinkToCsv({ bitlink: 'bit.ly/x' });
+    expect(csv).toContain('Bitlink,bit.ly/x');
+    expect(csv).toContain('Total Clicks,0');
+    expect(csv).toContain('Daily Clicks');
+    expect(csv).toContain('Countries');
+    expect(csv).toContain('Referrers');
+  });
+});


### PR DESCRIPTION
Advances #131 (adds the dedicated Bitly export the issue asks for).

## Context (from audit)
Bitly infra is extensive and country data already rides along in report CSVs, but there was **no dedicated Bitly export** — the admin Bitly page had sync/pull/refresh but no export.

## Change
- **`lib/bitlyExport.ts`** — pure `bitlyLinkToCsv` (sectioned: Summary / Daily Clicks / Countries / Referrers), `csvCell` (RFC-4180 escaping), `bitlyExportFilename`.
- **`app/api/bitly/analytics/[linkId]/route.ts`** — `?format=csv` returns `text/csv` + `Content-Disposition` from the **cached** `bitly_links` doc (no live Bitly call).
- **`app/admin/bitly/page.tsx`** — `📄 Export` button per link row.
- **`tests/bitly-export.test.ts`** — 8 cases.

## Verification
Full `ci.yml` gate green locally: `type-check`, `lint`, `test` (303, +8 new), `style:check`, `version:verify`, `docs:audit`, both guardrails, `build`.

⚠️ Visual QA of the Export button in `/admin/bitly` recommended (admin auth/DB not available in the authoring session).
⚠️ Version depends on #288/#289/#290/#291 merging first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)