### PR TITLE
fix: logo/image upload broken — NEXT_PUBLIC key not inlined client-side (#294), v12.1.27

### DIFF
--- a/docs/_meta/meta-docs-consistency-audit.md
+++ b/docs/_meta/meta-docs-consistency-audit.md
@@ -1,11 +1,11 @@
 # Docs Consistency Audit
 Status: Active
-Last Updated: 2026-07-02T06:24:17.579Z
+Last Updated: 2026-07-08T08:24:36.682Z
 Canonical: Yes
 Owner: Documentation
 
-Package version: 12.1.20
-Current docs scanned: 109
+Package version: 12.1.27
+Current docs scanned: 112
 Failures: 0
 
 ## Result

--- a/docs/_meta/meta-docs-link-check.md
+++ b/docs/_meta/meta-docs-link-check.md
@@ -1,6 +1,6 @@
 # Docs Link Check
 Status: Active
-Last Updated: 2026-07-07T14:19:01Z
+Last Updated: 2026-07-08T08:24:36Z
 Canonical: Yes
 Owner: Documentation
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -4,7 +4,7 @@ Last Updated: 2026-06-25
 Canonical: No
 Owner: Architecture
 
-Version: 12.1.20
+Version: 12.1.27
 
 **Mantine Entity, Variant, and Public Report Shell Delivery (2026-06-25):**
 - **Report variant selector recovery:** Mantine `Select` dropdowns inside report variant `FormModal` now render through a portal with modal-safe z-index, preventing the dropdown from being hidden behind or interpreted as outside the dialog.
@@ -4548,5 +4548,5 @@ When working with the hashtag categories system:
 ---
 
 *Last Updated: 2025-10-19T11:58:43.000Z*
-*Version: 12.1.20*
+*Version: 12.1.27*
 *Status: Production-Ready — Enterprise Event Analytics Platform with Advanced Analytics Infrastructure*

--- a/docs/components/components-reusable-components-inventory.md
+++ b/docs/components/components-reusable-components-inventory.md
@@ -4,7 +4,7 @@ Last Updated: 2026-04-24
 Canonical: No
 Owner: Architecture
 
-**Version**: 12.1.20
+**Version**: 12.1.27
 **Last Updated**: 2026-04-24 (UTC)
 **Purpose**: Complete catalog of all reusable components, modules, styling systems, and utilities
 
@@ -561,4 +561,4 @@ For implementation details, see:
 
 ---
 
-*Version: 12.1.20 | Last Updated: 2026-06-26 (UTC)*
+*Version: 12.1.27 | Last Updated: 2026-06-26 (UTC)*

--- a/docs/components/components-unified-input-system.md
+++ b/docs/components/components-unified-input-system.md
@@ -4,7 +4,7 @@ Last Updated: 2026-01-11T22:28:38.000Z
 Canonical: No
 Owner: Architecture
 
-**Version**: 12.1.20
+**Version**: 12.1.27
 **Last Updated**: 2026-01-11T22:28:38.000Z
 **Status**: Production-Ready
 

--- a/docs/design/design-system.md
+++ b/docs/design/design-system.md
@@ -4,7 +4,7 @@ Last Updated: 2026-06-26T10:00:00.000Z
 Canonical: Yes
 Owner: Architecture
 
-**Version**: 12.1.20
+**Version**: 12.1.27
 **Status**: Production
 
 ## Purpose

--- a/docs/guides/guides-form-input-migration-guide.md
+++ b/docs/guides/guides-form-input-migration-guide.md
@@ -4,7 +4,7 @@ Last Updated: 2026-01-11T22:28:38.000Z
 Canonical: No
 Owner: Product
 
-**Version**: 12.1.20
+**Version**: 12.1.27
 **Last Updated**: 2026-01-11T22:28:38.000Z
 **Purpose**: Prevent aggressive parsing anti-patterns in future forms
 

--- a/docs/guides/guides-input-system-complete.md
+++ b/docs/guides/guides-input-system-complete.md
@@ -5,7 +5,7 @@ Canonical: No
 Owner: Product
 
 **Date**: 2025-12-25T20:50:00.000Z
-**Version**: 12.1.20
+**Version**: 12.1.27
 **Status**: ✅ Complete - Production Ready
 
 ## 📋 Overview

--- a/docs/low-level-design.md
+++ b/docs/low-level-design.md
@@ -4,7 +4,7 @@ Last Updated: 2026-06-25T00:00:00.000Z
 Canonical: No
 Owner: Architecture
 
-Version: 12.1.20
+Version: 12.1.27
 
 This document captures implementation-level contracts for recently changed high-risk flows. It complements `docs/architecture.md`; it does not replace feature specs or API references.
 

--- a/docs/operations/operations-release-notes.md
+++ b/docs/operations/operations-release-notes.md
@@ -1,8 +1,30 @@
 # {messmass} Release Notes
 Status: Active
-Last Updated: 2026-07-02T06:23:29.000Z
+Last Updated: 2026-07-08T08:24:11.000Z
 Canonical: No
 Owner: Operations
+
+## [v12.1.27] — 2026-07-08T08:24:11.000Z
+
+### Summary
+FIX — LOGO/IMAGE UPLOAD BROKEN (#294): The public ImgBB key never reached the browser, so every direct browser→ImgBB upload (logos, report images) failed with "Image upload not configured". Fixed by reading `NEXT_PUBLIC_*` via static literal access so Next.js inlines it into the client bundle.
+
+### Root Cause
+`clientConfig()` in `lib/config.ts` read `NEXT_PUBLIC_IMGBB_API_KEY` via `getEnv()` — a dynamic `process.env[name]` access. Next.js only inlines `NEXT_PUBLIC_*` into the browser bundle for **static literal** accesses; a dynamic access is never inlined, so `clientConfig().imgbbApiKey` was always `undefined` client-side regardless of deployment env. Regression from `ae2fb1dc` (2026-07-01, direct-to-ImgBB upload); broken since it shipped.
+
+### What Was Fixed
+**WHAT**: `clientConfig()` now reads `process.env.NEXT_PUBLIC_APP_URL` / `NEXT_PUBLIC_WS_URL` / `NEXT_PUBLIC_IMGBB_API_KEY` as static literals (via a `cleanEnv` trim helper), not `getEnv()`.
+**WHY**: Static literal access is the only form Next.js inlines into client bundles. This restores logo/image uploads in `components/ImageUploader.tsx`, `components/ImageUploadField.tsx`, `components/ReportContentManager.tsx`.
+
+### Verification
+Built with `NEXT_PUBLIC_IMGBB_API_KEY=<sentinel>` and grepped `.next/static`:
+- before (dynamic `getEnv`): sentinel in **0** client chunks
+- after (static literal): sentinel in **3** client chunks (incl. `app/admin/partners`, `app/admin/content-library`)
+
+No jest test — the bug is a build-time inlining behavior that a Node-runtime unit test cannot reproduce (`process.env[name]` works at runtime); the build+grep is the guard.
+
+### Testing
+- `npm run type-check`, `npm run lint`, `npm test` (303 passing), `npm run style:check`, `npm run version:verify`, `npm run docs:audit`, both guardrails, `npm run build`
 
 ## [v12.1.20] — 2026-07-02T06:23:29.000Z
 

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -163,15 +163,27 @@ export const env = {
 };
 
 // Client-safe configuration: expose only NEXT_PUBLIC_* values
+//
+// CRITICAL: read NEXT_PUBLIC_* via STATIC literal `process.env.NEXT_PUBLIC_X`,
+// never via getEnv()/`process.env[name]`. Next.js only inlines NEXT_PUBLIC_*
+// into the browser bundle for static literal accesses; a dynamic `process.env[name]`
+// is NOT inlined and resolves to `undefined` in the browser. Using getEnv() here
+// meant `imgbbApiKey` was always undefined client-side, so every direct
+// browser→ImgBB upload (logos, report images) failed with "Image upload not
+// configured" regardless of deployment env (regression from ae2fb1dc).
+function cleanEnv(v: string | undefined): string | undefined {
+  return v && v.trim() !== '' ? v.trim() : undefined;
+}
+
 export function clientConfig() {
   return {
-    appUrl: getEnv('NEXT_PUBLIC_APP_URL'),
-    wsUrl: getEnv('NEXT_PUBLIC_WS_URL'),
+    appUrl: cleanEnv(process.env.NEXT_PUBLIC_APP_URL),
+    wsUrl: cleanEnv(process.env.NEXT_PUBLIC_WS_URL),
     // WHAT: Public ImgBB key for direct browser-to-ImgBB uploads
     // WHY: Proxying file uploads through our own serverless function hit
     //      Vercel's hard 4.5MB request body cap (413). Uploading straight
     //      from the browser bypasses that cap entirely (ImgBB allows 32MB).
-    imgbbApiKey: getEnv('NEXT_PUBLIC_IMGBB_API_KEY'),
+    imgbbApiKey: cleanEnv(process.env.NEXT_PUBLIC_IMGBB_API_KEY),
   } as const;
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "messmass",
-  "version": "12.1.20",
+  "version": "12.1.27",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "messmass",
-      "version": "12.1.20",
+      "version": "12.1.27",
       "license": "MIT",
       "dependencies": {
         "@mantine/core": "^8.3.18",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "messmass",
-  "version": "12.1.20",
+  "version": "12.1.27",
   "description": "Enterprise-grade event analytics platform with comprehensive partner management, intelligent link tracking, automated event creation (Sports Match Builder), and advanced real-time statistics dashboard for sports organizations, venues, brands, and event managers",
   "keywords": [
     "event-statistics",
@@ -135,14 +135,14 @@
     "ops:partner-report:logs:fail": "node scripts/auditPartnerReportLogs.mjs --fail-on-errors"
   },
   "dependencies": {
-    "@sovereignsquad/gds-admin": "^3.9.0",
-    "@sovereignsquad/gds-core": "^3.9.0",
-    "@sovereignsquad/gds-theme": "^3.9.0",
     "@mantine/core": "^8.3.18",
     "@mantine/form": "^8.3.18",
     "@mantine/hooks": "^8.3.18",
     "@mantine/modals": "^8.3.18",
     "@mantine/notifications": "^8.3.18",
+    "@sovereignsquad/gds-admin": "^3.9.0",
+    "@sovereignsquad/gds-core": "^3.9.0",
+    "@sovereignsquad/gds-theme": "^3.9.0",
     "@tabler/icons-react": "^3.44.0",
     "bcryptjs": "^3.0.3",
     "chart.js": "^4.5.1",


### PR DESCRIPTION
Closes #294.

## Symptom
Client reported logo image upload not working ("upload path is missing").

## Root cause (confirmed)
`clientConfig()` in `lib/config.ts` read `NEXT_PUBLIC_IMGBB_API_KEY` via `getEnv()` — a **dynamic** `process.env[name]` access. Next.js only inlines `NEXT_PUBLIC_*` into the **browser** bundle for **static literal** accesses (`process.env.NEXT_PUBLIC_IMGBB_API_KEY`). Dynamic access is never inlined, so `clientConfig().imgbbApiKey` was **always `undefined` in the browser**, and every direct browser→ImgBB upload (`ImageUploader`, `ImageUploadField`, `ReportContentManager` via `lib/imgbbClientUpload.ts`) failed with "Image upload not configured" — regardless of deployment env.

Regression from `ae2fb1dc` (2026-07-01, "upload directly to ImgBB to avoid 413"); broken since the direct-upload path shipped.

## Fix
`clientConfig()` reads `NEXT_PUBLIC_*` via **static literals** (with a `cleanEnv` trim helper preserving prior empty→undefined behavior).

## Proof (build + grep, no auth/DB needed)
Built with `NEXT_PUBLIC_IMGBB_API_KEY=SENTINEL_IMGBB_9Z9Z`, grepped `.next/static`:
| | client chunks containing the key |
|---|---|
| before (dynamic `getEnv`) | **0** |
| after (static literal) | **3** (incl. `app/admin/partners`, `app/admin/content-library`) |

⚠️ No jest test on purpose: the defect is Next.js build-time inlining, which a Node-runtime unit test can't reproduce (`process.env[name]` works at runtime — which is exactly why it slipped through). The build+grep is the real guard; the fix carries a comment documenting the static-access constraint.

## Deploy note
Ensure `NEXT_PUBLIC_IMGBB_API_KEY` is set in the deployment's **build** environment (it's inlined at build time, not runtime).

## Verification
Full `ci.yml` gate green locally: `type-check`, `lint`, `test` (303), `style:check`, `version:verify`, `docs:audit`, both guardrails, `build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)