### PR TITLE
Auto-provision camera events on messmass event create (full circle, messmass as master)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -72,3 +72,8 @@ JWT_SECRET=
 # - Keep secrets in environment providers; never in DB unless an approved encryption scheme exists.
 # - Client-visible values MUST use NEXT_PUBLIC_*.
 # - In production, all ENABLE_*_SECURITY flags MUST be set to true.
+
+# --- messmass -> camera provisioning (messmass is master for orgs/partners/events) ---
+# When set, creating an event auto-provisions the mirror event in camera.
+CAMERA_BASE_URL=http://localhost:3000
+CAMERA_MESSMASS_INTERNAL_SECRET=

--- a/app/api/integrations/camera/link-partners/route.ts
+++ b/app/api/integrations/camera/link-partners/route.ts
@@ -1,0 +1,16 @@
+import { NextRequest } from 'next/server';
+import { getDb, handleRouteError, jsonSuccess, requireFanmassIntegrationAuth } from '@/lib/fanmassIntegration';
+import { linkExistingPartners } from '@/lib/cameraProvision';
+
+// POST /api/integrations/camera/link-partners
+// Ops: link messmass partners to existing camera partners by name (no creation).
+export async function POST(request: NextRequest) {
+  const authError = requireFanmassIntegrationAuth(request);
+  if (authError) return authError;
+  try {
+    const db = await getDb();
+    return jsonSuccess(await linkExistingPartners(db));
+  } catch (err) {
+    return handleRouteError(err);
+  }
+}

--- a/app/api/integrations/camera/provision-missing/route.ts
+++ b/app/api/integrations/camera/provision-missing/route.ts
@@ -1,0 +1,18 @@
+import { NextRequest } from 'next/server';
+import { getDb, handleRouteError, jsonSuccess, requireFanmassIntegrationAuth } from '@/lib/fanmassIntegration';
+import { provisionMissingEvents } from '@/lib/cameraProvision';
+
+// POST /api/integrations/camera/provision-missing?limit=100
+// Ops backfill: provision camera events for existing messmass events that have a
+// partner but no camera link yet.
+export async function POST(request: NextRequest) {
+  const authError = requireFanmassIntegrationAuth(request);
+  if (authError) return authError;
+  try {
+    const db = await getDb();
+    const limit = Number.parseInt(request.nextUrl.searchParams.get('limit') || '100', 10);
+    return jsonSuccess(await provisionMissingEvents(db, Number.isFinite(limit) && limit > 0 ? Math.min(limit, 500) : 100));
+  } catch (err) {
+    return handleRouteError(err);
+  }
+}

--- a/app/api/projects/route.ts
+++ b/app/api/projects/route.ts
@@ -686,6 +686,18 @@ export async function POST(request: NextRequest) {
       }
     }
 
+    // WHAT: Provision the mirror event in the camera app (messmass is the master).
+    // WHY: Full circle — same partner/event everywhere; the camera event inherits
+    //      the partner's default design. Fire-and-forget; never blocks/fails create.
+    try {
+      const { provisionCameraEventForProject } = await import('@/lib/cameraProvision');
+      void provisionCameraEventForProject(db, { ...project, _id: result.insertedId }).catch((err) =>
+        logError('Camera provisioning failed', { context: 'projects', projectId: result.insertedId.toString() }, err instanceof Error ? err : new Error(String(err))),
+      );
+    } catch (provisionError) {
+      logError('Camera provisioning import failed', { context: 'projects', projectId: result.insertedId.toString() }, provisionError instanceof Error ? provisionError : new Error(String(provisionError)));
+    }
+
     // WHAT: Log notification for project creation
     // WHY: Notify all users of new project activity
     try {

--- a/lib/cameraClient.ts
+++ b/lib/cameraClient.ts
@@ -1,0 +1,48 @@
+/**
+ * Client for the camera provisioning API (camera PR #87). messmass (the master)
+ * calls camera's token-authed /api/internal/messmass/* endpoints to create/link
+ * organisations, partners and events. Auth = shared secret (config.cameraProvisionToken).
+ */
+import config from '@/lib/config';
+
+function base(): string {
+  return (config.cameraBaseUrl || '').replace(/\/$/, '');
+}
+function token(): string {
+  return config.cameraProvisionToken || '';
+}
+export function cameraConfigured(): boolean {
+  return Boolean(config.cameraBaseUrl && config.cameraProvisionToken);
+}
+
+async function req(method: string, path: string, body?: unknown): Promise<Record<string, unknown>> {
+  const res = await fetch(`${base()}${path}`, {
+    method,
+    headers: {
+      'content-type': 'application/json',
+      'x-messmass-secret': token(),
+      authorization: `Bearer ${token()}`,
+    },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+  const json = (await res.json().catch(() => ({}))) as Record<string, unknown>;
+  if (!res.ok) {
+    throw new Error(`camera_${res.status}:${JSON.stringify(json).slice(0, 200)}`);
+  }
+  return (json.data !== undefined ? json.data : json) as Record<string, unknown>;
+}
+
+export const cameraClient = {
+  upsertOrganization: (name: string, messmassOrganizationId: string) =>
+    req('POST', '/api/internal/messmass/organizations', { name, messmassOrganizationId }).then((d) => d.organization as { organizationId: string }),
+  upsertPartner: (input: { name: string; messmassPartnerId: string; organizationId?: string; logoUrl?: string }) =>
+    req('POST', '/api/internal/messmass/partners', input).then((d) => d.partner as { partnerId: string; linked: boolean; created: boolean }),
+  findPartners: (params: { name?: string; messmassPartnerId?: string }) => {
+    const q = new URLSearchParams();
+    if (params.name) q.set('name', params.name);
+    if (params.messmassPartnerId) q.set('messmassPartnerId', params.messmassPartnerId);
+    return req('GET', `/api/internal/messmass/partners?${q.toString()}`).then((d) => (d.partners as Array<{ partnerId: string; name: string }>) || []);
+  },
+  provisionEvent: (input: { messmassEventId: string; partnerId: string; eventName: string; eventDate?: string }) =>
+    req('POST', '/api/internal/messmass/events', input).then((d) => d.event as { eventId: string; mongoId: string; created: boolean }),
+};

--- a/lib/cameraProvision.ts
+++ b/lib/cameraProvision.ts
@@ -1,0 +1,97 @@
+/**
+ * messmass -> camera provisioning engine. messmass is the source of truth; these
+ * helpers mirror an organisation/partner/event into camera and stamp the camera
+ * ids back onto the messmass records (shared identity). Called (fire-and-forget)
+ * when a messmass event is created, and available as ops backfill/link helpers.
+ */
+import { ObjectId, type Db } from 'mongodb';
+import { cameraClient, cameraConfigured } from './cameraClient';
+
+export async function ensureCameraOrganization(db: Db, organizationId: ObjectId): Promise<string | undefined> {
+  const org = await db.collection('organizations').findOne({ _id: organizationId });
+  if (!org) return undefined;
+  if (org.cameraOrganizationId) return org.cameraOrganizationId as string;
+  const created = await cameraClient.upsertOrganization(org.name, String(org._id));
+  await db.collection('organizations').updateOne({ _id: org._id }, { $set: { cameraOrganizationId: created.organizationId } });
+  return created.organizationId;
+}
+
+export async function ensureCameraPartner(db: Db, partnerId: ObjectId): Promise<string | null> {
+  const partner = await db.collection('partners').findOne({ _id: partnerId });
+  if (!partner) return null;
+  if (partner.cameraPartnerId) return partner.cameraPartnerId as string;
+  let cameraOrgId: string | undefined;
+  if (partner.organizationId instanceof ObjectId) {
+    cameraOrgId = await ensureCameraOrganization(db, partner.organizationId);
+  }
+  const created = await cameraClient.upsertPartner({
+    name: partner.name,
+    messmassPartnerId: String(partner._id),
+    organizationId: cameraOrgId,
+    logoUrl: partner.logoUrl,
+  });
+  await db.collection('partners').updateOne({ _id: partner._id }, { $set: { cameraPartnerId: created.partnerId } });
+  return created.partnerId;
+}
+
+export async function provisionCameraEventForProject(db: Db, project: Record<string, unknown>): Promise<{ provisioned: boolean; reason?: string; cameraEventId?: string }> {
+  if (!cameraConfigured()) return { provisioned: false, reason: 'camera_not_configured' };
+  const projectId = project._id as ObjectId;
+  const partnerRef = (project.partner1Id as ObjectId | string | undefined) || (project.partnerId as ObjectId | string | undefined);
+  if (!partnerRef) return { provisioned: false, reason: 'no_partner' };
+  const partnerObjId = partnerRef instanceof ObjectId ? partnerRef : (ObjectId.isValid(String(partnerRef)) ? new ObjectId(String(partnerRef)) : null);
+  if (!partnerObjId) return { provisioned: false, reason: 'invalid_partner' };
+
+  const cameraPartnerId = await ensureCameraPartner(db, partnerObjId);
+  if (!cameraPartnerId) return { provisioned: false, reason: 'partner_unresolved' };
+
+  const event = await cameraClient.provisionEvent({
+    messmassEventId: String(projectId),
+    partnerId: cameraPartnerId,
+    eventName: String(project.eventName || 'Untitled event'),
+    eventDate: project.eventDate ? String(project.eventDate) : undefined,
+  });
+  await db.collection('projects').updateOne(
+    { _id: projectId },
+    { $set: { 'externalRefs.camera': { eventId: event.eventId, mongoId: event.mongoId, provisionedAt: new Date().toISOString() } } },
+  );
+  return { provisioned: true, cameraEventId: event.eventId };
+}
+
+/** Ops: link messmass partners to existing camera partners by name (no creation). */
+export async function linkExistingPartners(db: Db): Promise<{ linked: number; scanned: number }> {
+  if (!cameraConfigured()) return { linked: 0, scanned: 0 };
+  const partners = await db.collection('partners').find({ cameraPartnerId: { $exists: false } }).toArray();
+  let linked = 0;
+  for (const p of partners) {
+    try {
+      const found = await cameraClient.findPartners({ name: p.name });
+      if (found.length) {
+        await cameraClient.upsertPartner({ name: p.name, messmassPartnerId: String(p._id) });
+        await db.collection('partners').updateOne({ _id: p._id }, { $set: { cameraPartnerId: found[0].partnerId } });
+        linked++;
+      }
+    } catch {
+      // skip one bad partner, keep going
+    }
+  }
+  return { linked, scanned: partners.length };
+}
+
+/** Ops: backfill camera events for projects that have a partner but no camera link. */
+export async function provisionMissingEvents(db: Db, limit = 100): Promise<{ provisioned: number; scanned: number }> {
+  if (!cameraConfigured()) return { provisioned: 0, scanned: 0 };
+  const projects = await db.collection('projects')
+    .find({ 'externalRefs.camera': { $exists: false }, $or: [{ partner1Id: { $exists: true } }, { partnerId: { $exists: true } }] })
+    .limit(limit).toArray();
+  let provisioned = 0;
+  for (const project of projects) {
+    try {
+      const r = await provisionCameraEventForProject(db, project);
+      if (r.provisioned) provisioned++;
+    } catch {
+      // skip one, keep going
+    }
+  }
+  return { provisioned, scanned: projects.length };
+}

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -52,6 +52,9 @@ export type AppConfig = {
   fanmassBaseUrl?: string;
   fanmassApiKey?: string;
   fanmassIntegrationToken?: string;
+  // messmass -> camera provisioning (messmass is master for orgs/partners/events)
+  cameraBaseUrl?: string;
+  cameraProvisionToken?: string;
 };
 
 function getEnv(name: string): string | undefined {
@@ -130,6 +133,8 @@ function initializeConfig(): AppConfig {
     fanmassBaseUrl: getEnv('FANMASS_BASE_URL'),
     fanmassApiKey: getEnv('FANMASS_API_KEY'),
     fanmassIntegrationToken: getEnv('FANMASS_INTEGRATION_TOKEN') || getEnv('MESSMASS_FANMASS_TOKEN'),
+    cameraBaseUrl: getEnv('CAMERA_BASE_URL'),
+    cameraProvisionToken: getEnv('CAMERA_MESSMASS_INTERNAL_SECRET'),
   };
 
   return cachedConfig;

--- a/lib/csrf.ts
+++ b/lib/csrf.ts
@@ -176,7 +176,7 @@ export function requiresCsrfProtection(request: NextRequest): boolean {
   // WHY: CSRF (double-submit cookie) protects cookie/browser sessions; it does not
   //      apply to cookieless server-to-server calls carrying a bearer/api-key token.
   //      Requiring CSRF here would 403 every fanmass call (incl. link/callbacks/sync).
-  if (pathname.startsWith('/api/integrations/fanmass/')) {
+  if (pathname.startsWith('/api/integrations/')) {
     return false;
   }
 

--- a/lib/fanmassMapping.ts
+++ b/lib/fanmassMapping.ts
@@ -196,31 +196,36 @@ export async function createVariable(input: { name: string; label?: string; type
     throw Object.assign(new Error('Variable name must be camelCase (letters/digits, starting with a letter)'), { status: 400, code: 'INVALID_VARIABLE_NAME' });
   }
   const db = await getDb();
-  const existing = await db.collection('variables_metadata').findOne({ name });
-  const setOnInsert: Record<string, unknown> = {
-    name,
-    isSystem: false,
-    type: input.type || 'count',
-    category: input.category || 'Custom',
-    derived: false,
-    flags: { visibleInClicker: false, editableInManual: true },
-    order: 999,
-    label: input.label || name,
-    createdAt: nowIso(),
-  };
-  const set: Record<string, unknown> = { updatedAt: nowIso() };
+  const col = db.collection('variables_metadata');
+  const existing = await col.findOne({ name });
   if (existing) {
+    // Only touch provided fields on update (never both $set and $setOnInsert on the
+    // same path — Mongo rejects that as a conflict).
+    const set: Record<string, unknown> = { updatedAt: nowIso() };
     if (input.label) set.label = input.label;
     if (input.type) set.type = input.type;
     if (input.category) set.category = input.category;
     if (input.unit !== undefined) set.unit = input.unit;
     if (input.description !== undefined) set.description = input.description;
+    await col.updateOne({ name }, { $set: set });
   } else {
-    if (input.unit !== undefined) setOnInsert.unit = input.unit;
-    if (input.description !== undefined) setOnInsert.description = input.description;
+    const now = nowIso();
+    await col.insertOne({
+      name,
+      isSystem: false,
+      type: input.type || 'count',
+      category: input.category || 'Custom',
+      label: input.label || name,
+      derived: false,
+      flags: { visibleInClicker: false, editableInManual: true },
+      order: 999,
+      ...(input.unit !== undefined ? { unit: input.unit } : {}),
+      ...(input.description !== undefined ? { description: input.description } : {}),
+      createdAt: now,
+      updatedAt: now,
+    });
   }
-  await db.collection('variables_metadata').updateOne({ name }, { $set: set, $setOnInsert: setOnInsert }, { upsert: true });
-  const saved = await db.collection('variables_metadata').findOne({ name });
+  const saved = await col.findOne({ name });
   return { variable: toVariable(saved), created: !existing };
 }
 


### PR DESCRIPTION
Phase 2/3 of the full-circle architecture. When an event is created in messmass (`POST /api/projects`), a fire-and-forget hook mirrors it into camera (camera PR #87): ensure org+partner exist in camera (hybrid link-by-name-or-create, no duplicates), create the camera event (inherits the partner's default design, editable in camera), and stamp shared identity both ways (`project.externalRefs.camera`, partner `cameraPartnerId`↔camera `messmassPartnerId`). Adds `lib/cameraClient.ts` + `lib/cameraProvision.ts`, ops routes (link-partners, provision-missing backfill), broadens the integration CSRF exemption to `/api/integrations/*`, and `CAMERA_BASE_URL`+`CAMERA_MESSMASS_INTERNAL_SECRET` config. **Verified live**: created an event → camera event appeared under AS Roma (#831100, 4 logos), linked both ways, externalRefs stamped; cleaned up. Stacked on #296. 🤖 Generated with [Claude Code](https://claude.com/claude-code)