### PR TITLE
fix: run camera provisioning in after() (survives serverless)

### DIFF
--- a/app/api/projects/route.ts
+++ b/app/api/projects/route.ts
@@ -1,4 +1,4 @@
-import { NextRequest, NextResponse } from 'next/server';
+import { NextRequest, NextResponse, after } from 'next/server';
 import { ObjectId, Db } from 'mongodb';
 import { generateProjectSlugs } from '@/lib/slugUtils';
 import clientPromise from '@/lib/mongodb';
@@ -688,15 +688,19 @@ export async function POST(request: NextRequest) {
 
     // WHAT: Provision the mirror event in the camera app (messmass is the master).
     // WHY: Full circle — same partner/event everywhere; the camera event inherits
-    //      the partner's default design. Fire-and-forget; never blocks/fails create.
-    try {
-      const { provisionCameraEventForProject } = await import('@/lib/cameraProvision');
-      void provisionCameraEventForProject(db, { ...project, _id: result.insertedId }).catch((err) =>
-        logError('Camera provisioning failed', { context: 'projects', projectId: result.insertedId.toString() }, err instanceof Error ? err : new Error(String(err))),
-      );
-    } catch (provisionError) {
-      logError('Camera provisioning import failed', { context: 'projects', projectId: result.insertedId.toString() }, provisionError instanceof Error ? provisionError : new Error(String(provisionError)));
-    }
+    //      the partner's default design. Runs via after() so it completes AFTER the
+    //      response WITHOUT being suspended (a plain fire-and-forget is killed by the
+    //      serverless runtime once the response is returned). Never blocks/fails create.
+    const provisionProject = { ...project, _id: result.insertedId };
+    after(async () => {
+      try {
+        const { getDb } = await import('@/lib/fanmassIntegration');
+        const { provisionCameraEventForProject } = await import('@/lib/cameraProvision');
+        await provisionCameraEventForProject(await getDb(), provisionProject);
+      } catch (err) {
+        logError('Camera provisioning failed', { context: 'projects', projectId: result.insertedId.toString() }, err instanceof Error ? err : new Error(String(err)));
+      }
+    });
 
     // WHAT: Log notification for project creation
     // WHY: Notify all users of new project activity

--- a/docs/guides/guides-tutorial-authentication-sso.md
+++ b/docs/guides/guides-tutorial-authentication-sso.md
@@ -1,0 +1,181 @@
+# Tutorial: Authentication, roles & SSO
+Status: Active
+Last Updated: 2026-07-20T00:00:00.000Z
+Canonical: Yes
+Owner: Documentation
+
+> Audience: Operators and technical implementers · Prerequisites: Admin sign-in for most tasks; environment access for setup · Related: [Sharing & access](guides-tutorial-sharing-access.md), [Organisations](guides-tutorial-organisations.md), [Bitly integration](guides-tutorial-bitly.md)
+
+## What it is & why it matters
+
+messmass controls who can do what through a small number of cooperating mechanisms. Getting them right is what keeps event data private while still letting employees, partners and integrations do their jobs.
+
+There are three ways to be recognised by messmass:
+
+1. **Admin sign-in** — an email + password checked against the `users` collection. This grants a session and access to the admin console.
+2. **Page passwords** — per-page share links that let someone view or edit a single event without any admin account (recapped below; covered fully in [Sharing & access](guides-tutorial-sharing-access.md)).
+3. **API keys** — a user's password used as a Bearer token for the public REST API, so external systems can read (and, when permitted, write) data.
+
+On top of admin sign-in, an optional **DoneIsBetter SSO** flow lets an organisation use its own identity provider instead of local passwords.
+
+Why it matters: these layers are the difference between "a partner can see their own event report" and "anyone can edit anyone's data." The role attached to each user, and the flags on their account, decide the blast radius.
+
+## Before you start
+
+- **To manage users or sign in to the console** you need an admin account already present in the `users` collection.
+- **To enable SSO or the production security flags** you need access to the deployment environment variables.
+- **Never paste secret values anywhere in the app or in documentation.** Everything below refers to environment variables and account fields by name only.
+
+## Step by step
+
+### 1. Sign in to the admin console
+
+Go to **`/admin/login`** and enter your email and password. Emails are matched case-insensitively (they are normalised to lowercase). On success you receive an `admin-session` cookie (HttpOnly, valid for seven days), and the middleware lets you into `/admin/*`. The public admin routes that never require a session are `/admin/login`, `/admin/register` and `/admin/clear-session`; everything else under `/admin` redirects to the login page when you are not authenticated.
+
+### 2. Understand the roles
+
+Users carry one of five roles (`UserRole`): **guest**, **user**, **admin**, **superadmin**, **api**.
+
+- **guest** — the lowest tier, for minimal or no console privileges.
+- **user** — an authenticated account intended for day-to-day, non-privileged work.
+- **admin** — full access to the admin console and its management screens.
+- **superadmin** — the top tier; a superadmin passes every permission check unconditionally.
+- **api** — an account intended for programmatic access rather than interactive console use.
+
+Permission checks combine the role with a permission list. A superadmin short-circuits to "allowed" for any permission; other roles are checked against their granted permissions.
+
+| Role | Intended use | Rough capability |
+|------|--------------|------------------|
+| `guest` | Minimal / no console access | Lowest tier |
+| `user` | Everyday authenticated work | Non-privileged account |
+| `admin` | Console management | Full admin console |
+| `superadmin` | Platform owner | Passes every permission check |
+| `api` | Programmatic access | Designated for integrations |
+
+> Note: The role-to-permission mapping is still evolving in the codebase — superadmin is the reliably all-powerful tier, while the finer-grained distinctions between guest/user/admin are applied per screen and per API route rather than by a single global table. Treat superadmin as "everything," admin as "console management," and guest/user/api as increasingly restricted, and verify a specific screen's behaviour if the exact boundary matters.
+
+Permission checks combine the role with a permission list, so a route can demand a specific capability (for example the ability to manage users) rather than a specific role. Superadmin is the escape hatch that always passes.
+
+### 3. Recap: page-password sharing
+
+When you need to give someone access to just one event — a client viewing a stats page, or an operator editing a single event — generate a **page password** instead of an account. Each page (stats, edit or filter) gets its own 32-character token that you share along with the link. Admin sessions bypass page passwords entirely. This is the right tool for external, scoped, temporary access. The full workflow is in [Sharing & access](guides-tutorial-sharing-access.md).
+
+> Note: A page password grants access to one page only; it is not an account and carries no role. Revoke access by regenerating that page's password.
+
+### 4. Optional: enable DoneIsBetter SSO
+
+Set the environment variable **`SSO_BASE_URL`** to your DoneIsBetter instance to turn SSO on. When it is set:
+
+- The login page shows a **"Sign in with DoneIsBetter"** option.
+- `/api/auth/sso/login` redirects the user into the SSO provider.
+- `/api/auth/sso/callback` validates the returned token against `SSO_BASE_URL/api/validate`, looks the user up **by email**, and — on a match — issues the same `admin-session` cookie plus an `auth-source=sso` marker, then returns the user to `/admin` (or to another safe path that starts with `/admin`).
+
+**SSO does not create accounts.** The email returned by the identity provider must already exist in the `users` collection; if it does not, the callback redirects to the login page with a `no_account` error. Provision the user in messmass first, then let them sign in through SSO.
+
+When SSO is configured, dashboard routes are held to a higher bar: `/admin/dashboard` (and the extended `/dashboard` analytics routes) require an SSO-backed session, while other admin routes still accept a local session as a fallback.
+
+The SSO sign-in flow, end to end:
+
+1. The user clicks "Sign in with DoneIsBetter" on `/admin/login`.
+2. `/api/auth/sso/login` redirects them into the SSO provider at `SSO_BASE_URL`.
+3. After they authenticate there, the provider redirects back to `/api/auth/sso/callback` with a token.
+4. The callback validates the token against `SSO_BASE_URL/api/validate` and reads the user's email.
+5. It looks the email up in the `users` collection. **No match → redirect to login with `no_account`.**
+6. On a match it issues the `admin-session` cookie plus `auth-source=sso` and returns the user to a safe `/admin` path.
+
+### 5. Optional: use the public REST API
+
+The public API authenticates with a **Bearer token that is the user's password**, and only for users whose account has API access switched on. This keeps integration accountability tied to a real user record: every API call is attributable to the account whose key was used.
+
+- **Read access** requires the account's `apiKeyEnabled` flag to be true. Send `Authorization: Bearer <key>` — and **do not send cookies** (the API rejects cookie-bearing requests; it is Bearer-only).
+- **Write access** requires **both** `apiKeyEnabled` **and** `apiWriteEnabled`. Read-enabled keys that try to write get a 403 explaining that write access is not enabled.
+
+Usage is tracked per call (and separately for writes) for auditing. Turn these flags on only for the specific integration accounts that need them.
+
+A minimal read request looks like this (values shown as placeholders — never commit a real key):
+
+```
+GET /api/... HTTP/1.1
+Host: messmass.com
+Authorization: Bearer <the-user-password-acting-as-api-key>
+```
+
+The same request with a `Cookie` header would be rejected with `COOKIES_NOT_ALLOWED`. A write request to a create/update endpoint additionally needs the account's write flag; without it the response is a 403 with `WRITE_ACCESS_DISABLED`.
+
+| Scope | Requires | Middleware behaviour |
+|-------|----------|----------------------|
+| Read | `apiKeyEnabled = true` | Rejects missing/invalid tokens and any cookie-bearing request |
+| Write | `apiKeyEnabled = true` **and** `apiWriteEnabled = true` | Read auth first, then a separate write-permission check |
+
+## Managing it
+
+- **Sessions.** The `admin-session` cookie is HttpOnly, SameSite=Lax, Secure in production, and expires after seven days. A `session-format` marker tells messmass whether the token is a signed JWT or the legacy encoding. Logout deletes the cookie.
+- **Turn on the production security flags.** In production the app **refuses to start** unless all four security feature flags are enabled. Set each to `true`:
+  - `ENABLE_BCRYPT_AUTH` — hash passwords with bcrypt instead of storing them in plaintext.
+  - `ENABLE_JWT_SESSIONS` — issue cryptographically signed session tokens instead of unsigned ones.
+  - `ENABLE_HTML_SANITIZATION` — sanitise rendered HTML to block XSS.
+  - `ENABLE_SAFE_FORMULA_PARSER` — evaluate chart formulas with the safe parser instead of a raw function constructor.
+  A startup check lists exactly which flags are missing and how to fix them, so a misconfigured production deploy fails loudly rather than running insecurely.
+- **User management** is done from the admin console (create users, regenerate a user's password, toggle API and write access, delete users). Passwords double as API keys, so regenerating a password also rotates that user's API key.
+- **Middleware runs on every request.** Before a request reaches a route handler, the middleware enforces admin-route protection, rate limiting, CSRF checks on state-changing methods, and CORS. This is why direct `fetch` POST/PUT/DELETE calls from the browser need the CSRF token that the app's own API client attaches automatically — hand-rolled requests without it are refused.
+- **Two audiences, two authenticators.** Interactive console/dashboard users authenticate with the session cookie; integrations authenticate with a Bearer key. Keep them separate: never try to drive the public API with a browser session, and never expect a Bearer key to unlock the console UI.
+
+### Which access method for whom?
+
+| Situation | Use | Why |
+|-----------|-----|-----|
+| An operator managing events all day | Admin account (optionally via SSO) | Full console access, audited session |
+| A client who should only view one report | Page password | Scoped to a single page, no account needed |
+| An external system reading data | API key (read scope) | Bearer token, no console access |
+| An integration writing stats back | API key (read + write scope) | Requires both API flags, deliberately granted |
+| An organisation standardising on its own login | SSO | Central identity, but accounts must exist in messmass first |
+
+## Gotchas & good practice
+
+- **SSO requires pre-provisioned accounts.** The most common SSO surprise is a valid corporate login bouncing with `no_account`. Create the user in messmass (with the exact email) before they try SSO.
+- **The API is Bearer-only.** If an API call includes a `Cookie` header it is rejected outright. Integrations must authenticate purely with the Authorization header.
+- **Read and write are separate scopes.** Enabling API read does not enable write. Grant `apiWriteEnabled` deliberately, only to accounts that must push data.
+- **Passwords are credentials and API keys at once.** Because a user's password is also their API token, treat regeneration as a key rotation and update any integration that depends on it.
+- **Production must run with all four security flags on.** Do not disable them to "get a build working" — the flags exist because plaintext passwords, unsigned sessions, unsanitised HTML and an unrestricted formula evaluator are each a serious risk.
+- **Prefer page passwords for external viewers.** Do not hand out admin accounts for one-off report viewing; scope access to the single page instead.
+- **Secrets stay in the environment.** `SSO_BASE_URL`, the security flags, and any API keys are configured as environment variables and account fields — never embedded in the UI or shared in plain text.
+
+### Quick troubleshooting
+
+| Symptom | Likely cause | What to do |
+|---------|--------------|------------|
+| SSO login bounces with `no_account` | The email is not in the `users` collection | Create the user in messmass with the exact email, then retry |
+| Signed in but redirected away from `/admin/dashboard` | SSO configured but the session is local-only | Sign in through SSO; dashboards require an SSO-backed session |
+| Production deploy will not start | A required security flag is off | Set all four `ENABLE_*` flags to `true` and redeploy |
+| API call returns `COOKIES_NOT_ALLOWED` | The request sent a cookie | Use only the `Authorization: Bearer` header, no cookies |
+| API write returns `WRITE_ACCESS_DISABLED` | Account has read but not write | Enable `apiWriteEnabled` on that account |
+| Session drops after login | Cookie domain/secure mismatch | Verify the deploy domain and that HTTPS is in use in production |
+
+### Session and cookie reference
+
+| Property | Value |
+|----------|-------|
+| Session cookie | `admin-session` (HttpOnly, SameSite=Lax, Secure in production) |
+| Lifetime | 7 days |
+| Format marker | `session-format` (JWT when `ENABLE_JWT_SESSIONS` is on, otherwise legacy) |
+| SSO marker | `auth-source=sso` set on SSO logins |
+| Logout | Deletes the `admin-session` cookie |
+
+## How it connects
+
+- **Sharing & access** covers the page-password system in depth — the everyday way to give scoped access without accounts. See [Sharing & access](guides-tutorial-sharing-access.md).
+- **Organisations** determine which data a signed-in admin can reach; access is scoped by organisation membership. See [Organisations](guides-tutorial-organisations.md).
+- **The integrations** — [Bitly](guides-tutorial-bitly.md), [Sport databases](guides-tutorial-sport-databases.md) and [Google Sheets](guides-tutorial-google-sheets.md) — all sit behind admin authentication, and their scheduled jobs are authorised with the `CRON_SECRET` environment variable.
+
+For the full architecture, endpoint list and security-layer detail, see the feature guide at [../features/features-authentication.md](../features/features-authentication.md).
+
+## Screenshots
+_Screenshots to be added._
+
+## Related tutorials
+
+- [Sharing & access](guides-tutorial-sharing-access.md)
+- [Organisations](guides-tutorial-organisations.md)
+- [Getting started](guides-tutorial-getting-started.md)
+- [Bitly integration](guides-tutorial-bitly.md)
+- [Google Sheets sync](guides-tutorial-google-sheets.md)

--- a/docs/guides/guides-tutorial-bitly.md
+++ b/docs/guides/guides-tutorial-bitly.md
@@ -1,0 +1,181 @@
+# Tutorial: Bitly integration
+Status: Active
+Last Updated: 2026-07-20T00:00:00.000Z
+Canonical: Yes
+Owner: Documentation
+
+> Audience: Operators and technical implementers · Prerequisites: Admin sign-in, a Bitly account with API access · Related: [Partners](guides-tutorial-partners.md), [Reports](guides-tutorial-reports.md), [Google Sheets sync](guides-tutorial-google-sheets.md)
+
+## What it is & why it matters
+
+The Bitly integration pulls short-link click analytics **into** messmass (it is inbound only — messmass never creates or changes links in your Bitly account). Once a Bitly short link is imported, you attach it to the events and partners it belongs to, and its click totals, geography, referrers and daily trend become evidence you can show in reports.
+
+Why it matters: a fan-zone QR code, a printed poster, or a social campaign usually resolves through a `bit.ly/...` link. By importing that link and associating it with an event, the clicks it earned are attributed to that event automatically. Because association is many-to-many, a single link can feed several events, and one event can draw on several links.
+
+Everything lives on one admin screen: **`/admin/bitly`** ("🔗 Bitly Links"). Under the hood three collections cooperate:
+
+- `bitly_links` — the link plus its cached analytics (`click_summary`, `clicks_timeseries`, `geo.countries`, `referrers`, `referring_domains`, `lastSyncAt`).
+- `bitly_project_links` — the junction that ties a link to a project (event), with cached, date-bounded metrics per association (`startDate`, `endDate`, `autoCalculated`, `cachedMetrics`, `lastSyncedAt`).
+- `partners.bitlyLinkIds` — the reverse list stored on each partner record.
+
+Because the link-to-event relationship is a junction and not a single `projectId` on the link, one link can serve many events and one event can draw on many links — and each association carries its own cached metrics rather than a naive total-click count.
+
+### The header actions at a glance
+
+| Action | Icon | What it does |
+|--------|------|--------------|
+| Get Links from Bitly | ⬇️ | Import up to 100 new links from your Bitly group, skipping duplicates |
+| Sync Now | 🔄 | Refresh cached analytics for all links from Bitly |
+| Refresh Metrics | 📊 | Recalculate the cached, date-bounded metrics for every event-to-link association |
+| Add Link | + | Open the modal to add one link by short link or long URL |
+
+### The per-row actions at a glance
+
+| Action | Icon | What it does |
+|--------|------|--------------|
+| Pull | ⬇️ | Refresh this one link's analytics immediately (emergency use) |
+| Export | 📄 | Download this link's cached analytics as a sectioned CSV |
+| Archive | 🗑️ | Soft-archive the link (hidden from the list, data preserved) |
+
+## Before you start
+
+1. **Sign in as an admin.** The whole Bitly surface and every `/api/bitly/*` route is admin-only.
+2. **Provide Bitly credentials as environment variables** (never paste the values into the app or into docs):
+   - `BITLY_ACCESS_TOKEN` — your Bitly API v4 access token.
+   - `BITLY_GROUP_GUID` — the Bitly group whose links you want to import. (`BITLY_ORGANIZATION_GUID` is an optional fallback for accounts that require an organization GUID instead.)
+3. **Know your Bitly tier.** Growth-tier accounts have request rate limits; the client already spaces and retries calls, but imports are deliberately batched (100 links at a time) to stay within limits.
+4. **Have your events and partners created first** so there is something to associate links with. See [Events](guides-tutorial-events.md) and [Partners](guides-tutorial-partners.md).
+
+> Note: If `BITLY_ACCESS_TOKEN` is missing, the API fails fast with a clear "not configured" error rather than silently returning empty data.
+
+### How the client protects itself
+
+You do not need to manage rate limiting yourself, but it helps to know what happens under load. The Bitly client talks to Bitly API v4 with a request timeout, exponential backoff on transient failures (HTTP 429 and 5xx), and it honours a `Retry-After` header when Bitly sends one. It also surfaces the remaining rate-limit budget from response headers for observability. In practice this means a large import or sync degrades gracefully — it slows down rather than failing outright — but it is still worth spreading big imports across several clicks of **Get Links from Bitly** rather than expecting one click to pull thousands of links.
+
+## Step by step
+
+The typical order of operations is: import links, associate them with events and partners, let analytics refresh (on schedule or on demand), then read the results in reports. The subsections below follow that order.
+
+### 1. Import your links ("Get Links from Bitly")
+
+On `/admin/bitly`, click **Get Links from Bitly** (⬇️) in the header. This calls the import routine, which fetches up to 100 links from your configured Bitly group and imports only the ones not already stored — duplicates are skipped automatically. If you have more than 100 links, click the button again to pull the next batch.
+
+Freshly imported links may be **unassigned** at first. That is expected: import brings the link in; association is a separate, deliberate step.
+
+### 2. Add a single link by hand ("Add Link")
+
+Click **Add Link** (+) to open the modal. You can enter either a Bitly short link (`bit.ly/abc123`) or the original long URL. Optionally assign it to a project and give it a custom title (otherwise Bitly's own title is used). The form stays open after saving so you can attach the same link to more than one event in a row.
+
+### 3. Associate a link with events and partners
+
+Each row in the table has two association columns:
+
+- **Associated Projects** — use the "+ Add to event…" selector to attach the link to any event. Existing associations show as chips; click the ✕ on a chip to remove one. Because links are many-to-many, adding to a second event does not detach the first.
+- **Associated Partners** — use the "+ Add to partner…" selector. This writes to the partner's `bitlyLinkIds` list and is kept in sync in both directions, so the partner's own screens see the link too.
+
+### 4. Refresh analytics
+
+There are three refresh actions, from broad to narrow:
+
+- **Sync Now** (🔄) — refreshes cached analytics for all links from Bitly.
+- **Refresh Metrics** (📊) — recalculates the cached, date-bounded metrics for every event-to-link association (run this after a sync, or after event dates change).
+- **Per-link Pull** (⬇️ Pull on a row) — refreshes one link immediately. Treat this as an emergency override; routine refresh is handled by the daily schedule.
+
+### 5. Export one link's analytics ("CSV Export")
+
+The **📄 Export** button on a row downloads that link's cached analytics as a CSV built from the data already stored in messmass (it does not call Bitly). The file is sectioned into **Summary**, **Daily Clicks**, **Countries** and **Referrers**, so it can be dropped straight into a stakeholder report. The filename is derived from the bitlink (for example `bitly-bit.ly-abc123.csv`).
+
+> Note: Because Export reads cached data, it reflects whatever was captured at the last sync. If you need the very latest numbers in the CSV, run the row's **Pull** first, then Export.
+
+### 6. Archive links you no longer track
+
+The **🗑️ Archive** button on a row soft-archives the link: it disappears from the active list but its data is preserved. Archiving does not delete history, so metrics that already flowed into reports stay intact.
+
+### Worked example: a campaign link shared across two events
+
+Suppose one QR code (`bit.ly/club-fanzone`) is printed for a home match in March and reused for another in April:
+
+1. Click **Get Links from Bitly** to import `bit.ly/club-fanzone`.
+2. In its row, use "+ Add to event…" to attach it to the March event, then again to attach it to the April event.
+3. messmass splits the link's click history by date: the March event receives the earlier clicks, and the April event receives the ongoing clicks. The first event in the chain inherits all history before it; the last inherits everything after.
+4. Click **Refresh Metrics** so each association's cached total reflects the split.
+5. Each event's report now shows only the clicks attributable to that event's window — not the whole link's lifetime total.
+
+## Managing it
+
+### Reading the table
+
+Each row shows, left to right: a favorite star, the Bitly short link (a clickable external link), the title, the **Associated Projects** chips, the **Associated Partners** chips, the total **Clicks**, the **Last Synced** time, and the action buttons. The chips make it obvious at a glance which events and partners a link is feeding; an empty chip area means the link is imported but not yet attributed to anything.
+
+- **Search, filter, sort.** The header search box filters by bitlink, long URL or title. The "⭐ Show favorites only" checkbox narrows the list to links you have starred. Column headers (Bitly Link, Title, Clicks, Last Synced) sort on click and the sort is reflected in the URL so a sorted view can be shared.
+- **Favorites.** Click the star (☆/⭐) in the first column to mark links you refer to often.
+### When to use each refresh action
+
+| You want to… | Use | Why |
+|--------------|-----|-----|
+| Keep everything current with no effort | Nothing — the daily 3 AM UTC job | The recommended default; covers all links |
+| See a link's newest clicks right now | The row's **Pull** | Refreshes just that link on demand |
+| Refresh every link before a big report | **Sync Now** | Pulls fresh analytics for the whole set |
+| Fix per-event attribution after date changes | **Refresh Metrics** | Recomputes the date-bounded association caches |
+
+- **Scheduled refresh.** Analytics refresh automatically once a day (3:00 AM UTC). This runs against the sync route using a scheduled trigger authorized by the `CRON_SECRET` environment variable (sent as an `Authorization: Bearer` header). You do not run this by hand; the manual buttons exist for when you need data sooner.
+- **How totals surface downstream.** Once a link is associated with an event, its cached, date-bounded click totals roll into that event's analytics. Those Bitly totals also appear in the Google Sheets sync as **Total Bitly Clicks** and **Unique Bitly Clicks** columns, so spreadsheet-oriented partners see the same numbers (see [Google Sheets sync](guides-tutorial-google-sheets.md)).
+
+### What a synced link gives you
+
+Each synced link caches several analytics dimensions, all of which can feed reports and the per-link CSV export:
+
+- **Click summary** — total and unique clicks.
+- **Daily time series** — clicks per day for trend charts.
+- **Countries** — geographic distribution of clicks.
+- **Referrers and referring domains** — where the traffic came from (for example a social platform versus a QR scan), at both platform and domain granularity.
+
+Read APIs expose this data to reports: one endpoint returns a single link's analytics (with an optional live refresh), and another returns the aggregated, cached Bitly metrics for a whole event based on its current associations.
+
+## Gotchas & good practice
+
+- **Import first, associate second.** A link with no association contributes to no event. If a link's clicks are "missing" from a report, check that it is attached to the right event.
+- **Attribution is per-association, not a raw link total.** When a link is shared across events, messmass splits its history by date boundaries: the first event gets the early history, the last event gets the ongoing data, and events in between get bounded ranges. If the split looks wrong, run **Refresh Metrics**.
+- **After changing event dates, refresh metrics.** Date ranges for shared links are recalculated automatically when an event's date changes or an event is deleted, but running **Refresh Metrics** guarantees the caches are aligned before you publish a report.
+- **Rate limits.** If import returns a 403, check that `BITLY_ACCESS_TOKEN` has the right permissions. A 429 means you hit the rate limit — wait a moment and retry; imports are already batched to reduce this.
+- **Archiving is reversible in spirit, deletion is not.** Prefer Archive over permanent deletion so historical evidence survives.
+- **Never store secrets in the app or in a sheet.** The access token, group GUID and cron secret live only as environment variables.
+
+### Quick troubleshooting
+
+| Symptom | Likely cause | What to do |
+|---------|--------------|------------|
+| Links do not appear after import | Wrong or missing `BITLY_GROUP_GUID`, or they already exist | Confirm the group GUID; re-run import — existing links are skipped, not re-shown |
+| Import returns 403 / Forbidden | Access token lacks permission | Check `BITLY_ACCESS_TOKEN` scope in your Bitly account |
+| Import returns 429 / rate limited | Too many requests in a short window | Wait, then click Get Links again; batches of 100 keep you under the limit |
+| A report's click total looks wrong | Association caches are stale | Run **Refresh Metrics**, then re-check the event |
+| A link's own numbers look stale | Not synced recently | Use the row's **Pull**, or run **Sync Now** |
+| Partner association looked successful but the page still showed an error | A prior UI regression | Ensure you are on a current build; stale error state is cleared on success |
+
+## How it connects
+
+- **Partners** inherit Bitly links. A link attached to a partner can be carried into events created from that partner, so the [Partners](guides-tutorial-partners.md) workflow and the Bitly workflow reinforce each other.
+- **Reports** consume the cached per-event Bitly metrics — click totals, unique clicks, top countries and referrers — as part of an event's story. See [Reports](guides-tutorial-reports.md).
+- **Google Sheets** exposes Bitly totals to partners who manage events in a spreadsheet. See [Google Sheets sync](guides-tutorial-google-sheets.md).
+- The scheduled refresh shares the same `CRON_SECRET` pattern used by other daily jobs; see [Authentication, roles & SSO](guides-tutorial-authentication-sso.md) for how scheduled and API access are secured.
+
+### Where Bitly fits in a typical event
+
+1. A partner is created and given its Bitly link(s) — see [Partners](guides-tutorial-partners.md).
+2. An event is created (often from that partner), inheriting the link.
+3. During and after the event, clicks accrue on the link and are pulled into messmass by the daily sync.
+4. Association metrics are recalculated so each event gets its fair share of the clicks.
+5. The event's report and, if connected, its Google Sheet show the resulting Bitly totals.
+
+For the full data-model and API reference behind this screen, see the feature guide at [../features/features-bitly-integration-guide.md](../features/features-bitly-integration-guide.md).
+
+## Screenshots
+_Screenshots to be added._
+
+## Related tutorials
+
+- [Partners](guides-tutorial-partners.md)
+- [Reports](guides-tutorial-reports.md)
+- [Google Sheets sync](guides-tutorial-google-sheets.md)
+- [Sport databases](guides-tutorial-sport-databases.md)
+- [Authentication, roles & SSO](guides-tutorial-authentication-sso.md)

--- a/docs/guides/guides-tutorial-camera-app.md
+++ b/docs/guides/guides-tutorial-camera-app.md
@@ -1,0 +1,209 @@
+# Tutorial: Camera app integration
+Status: Active
+Last Updated: 2026-07-20T00:00:00.000Z
+Canonical: Yes
+Owner: Documentation
+
+> Audience: Operators + technical implementers · Prerequisites: You can create partners and events in messmass · Related: [Events](guides-tutorial-events.md) · [Partners](guides-tutorial-partners.md) · [Organisations](guides-tutorial-organisations.md) · [Fanmass](guides-tutorial-fanmass.md)
+
+## What it is & why it matters
+
+The Camera app is seyu's selfie / photo-capture product — the tool crews use on the
+ground to take fan selfies and event photos. messmass and the Camera app both need to
+agree on *who* an event belongs to: the same organisation, the same partner, the same
+event, identified the same way in both systems.
+
+The integration solves that by making **messmass the master (the source of truth)**.
+When you create an organisation, a partner, and an event in messmass, messmass
+**provisions** those records outbound *into* the Camera app and remembers the Camera-side
+IDs it gets back. You never have to re-key the same event into the Camera app — the two
+systems stay in sync because messmass pushes the identity to the Camera app for you.
+
+Three things make this safe to rely on:
+
+- **One direction.** messmass writes to the Camera app; the Camera app does not create
+  organisations, partners, or events back in messmass. There is no "who wins?" question.
+- **Shared IDs.** After provisioning, each messmass record stores the Camera app's ID
+  for the same thing, so future updates target the exact same Camera record instead of
+  creating duplicates.
+- **Fire-and-forget.** Provisioning happens in the background when you save an event. If
+  the Camera app is down, slow, or not configured, **your event still saves normally** —
+  provisioning simply retries later via a backfill (see [Managing it](#managing-it)).
+
+> Note: The messmass Clicker, KYC variables, and the content library are **internal
+> messmass systems**. They are not part of the Camera link and are not sent to the Camera
+> app. Don't conflate "the camera the crew uses" with messmass's own data-collection
+> tools. See [Collecting data](guides-tutorial-collecting-data.md).
+
+## Before you start
+
+The integration only runs when an administrator has configured two environment
+variables for the messmass deployment. These are **ops / admin setup**, not something you
+change in the app UI:
+
+| Environment variable | What it points at |
+| --- | --- |
+| `CAMERA_BASE_URL` | The base URL of the Camera app's provisioning API. |
+| `CAMERA_MESSMASS_INTERNAL_SECRET` | The shared secret that authenticates messmass to the Camera app. |
+
+Behaviour depending on configuration:
+
+- **Both set** → provisioning is active. Creating an event provisions it into the Camera
+  app.
+- **Either missing** → provisioning is **silently skipped**. Nothing errors; events still
+  save. Internally the provisioning call returns a reason of `camera_not_configured` and
+  moves on.
+
+> Note: Do not paste the secret value into documents, tickets, or screenshots. Only the
+> variable *names* belong in written material; the value lives in the deployment's secret
+> store.
+
+You do not need any special role to *trigger* provisioning — it fires automatically for
+anyone who can create an event. The **backfill / ops endpoints** described below are a
+separate, token-protected surface intended for operators.
+
+## Step by step
+
+### 1. Confirm the partner exists in messmass
+
+Provisioning an event needs a partner. During provisioning messmass looks at the event's
+`partner1Id` (its Partner 1 / home partner) — or a legacy single `partnerId` — to decide
+which Camera partner the event belongs to. If the event has **no partner**, provisioning
+stops early with reason `no_partner` and nothing is sent. So: create your partner first.
+See [Partners](guides-tutorial-partners.md).
+
+### 2. Create the event in messmass
+
+Create the event the normal way (see [Events](guides-tutorial-events.md)). When you save,
+messmass kicks off provisioning in the background. You do not click anything extra.
+
+Behind the scenes, provisioning cascades so the whole chain exists in the Camera app
+before the event does:
+
+1. **Organisation** — if the event's partner belongs to an organisation, messmass ensures
+   that organisation exists in the Camera app first (by name), and stores the returned
+   Camera ID on the messmass organisation as `organizations.cameraOrganizationId`.
+2. **Partner** — messmass ensures the partner exists in the Camera app (sending its name,
+   its messmass partner ID, the Camera organisation ID from step 1, and its logo URL if
+   set), and stores the returned Camera ID as `partners.cameraPartnerId`.
+3. **Event** — messmass creates the mirror event in the Camera app (sending the messmass
+   event ID, the Camera partner ID, the event name, and the event date if set), and stores
+   the returned Camera IDs on the messmass event as
+   `projects.externalRefs.camera` — an object holding `eventId`, `mongoId`, and a
+   `provisionedAt` timestamp.
+
+Each step is **idempotent**: if a record already carries its Camera ID, messmass reuses it
+instead of creating a second copy. So re-saving an event does not spawn duplicates in the
+Camera app.
+
+> Note: The Camera-side event inherits the partner's default design in the Camera app.
+> That styling is owned by the Camera app, not by messmass.
+
+### 3. Verify the link (optional)
+
+A successfully provisioned event has a populated `projects.externalRefs.camera` block with
+a `provisionedAt` timestamp. An operator with database access can confirm the three stored
+IDs are present:
+
+- `organizations.cameraOrganizationId`
+- `partners.cameraPartnerId`
+- `projects.externalRefs.camera.eventId`
+
+If any are missing, use the backfill endpoints below.
+
+## Managing it
+
+### Fire-and-forget means: check, then backfill
+
+Because provisioning never blocks event creation, an event can be created during a Camera
+app outage (or before the env vars were configured) and end up **without** a Camera link.
+messmass records the failure in the logs and moves on. Two operator endpoints exist to
+repair the gap. Both are `POST` and both require the integration token in the request
+(see [Authentication](#authentication-for-the-ops-endpoints)).
+
+**Link existing partners to Camera partners (no creation).**
+
+```
+POST /api/integrations/camera/link-partners
+```
+
+Scans messmass partners that do not yet have a `cameraPartnerId`, searches the Camera app
+for a partner **with the same name**, and — if a match is found — links the two by storing
+the Camera partner's ID back on the messmass partner. It does **not** create new Camera
+partners; it only connects records that already exist on both sides. Response reports how
+many partners were `linked` and how many were `scanned`.
+
+**Provision missing events.**
+
+```
+POST /api/integrations/camera/provision-missing?limit=100
+```
+
+Finds messmass events that have a partner but no `externalRefs.camera` link yet, and runs
+the full provisioning chain for each. `limit` defaults to `100` and is capped at `500` per
+call, so large backlogs are cleared in batches. Response reports how many events were
+`provisioned` and how many were `scanned`. One event failing does not stop the rest.
+
+### Authentication for the ops endpoints
+
+> Note: The two `/api/integrations/camera/...` backfill endpoints are protected by the
+> **Fanmass integration token** (`FANMASS_INTEGRATION_TOKEN`), *not* by
+> `CAMERA_MESSMASS_INTERNAL_SECRET`. The Camera secret authenticates messmass *outbound to
+> the Camera app*; the integration token authenticates operators *inbound to messmass*.
+> Send it as `Authorization: Bearer <token>` or `x-api-key: <token>`. If the token is not
+> configured the endpoints return `503`; a wrong token returns `401`. See
+> [Fanmass](guides-tutorial-fanmass.md) for how that token is set.
+
+### Day-to-day
+
+For normal operation there is nothing to manage: create partners and events, and the links
+appear on their own. Reach for the backfill endpoints only after an outage, after first
+enabling the integration, or when auditing reveals events created before the env vars were
+in place.
+
+## Gotchas & good practice
+
+- **No partner, no provisioning.** An event with no Partner 1 (and no legacy `partnerId`)
+  is skipped with reason `no_partner`. Attach a partner, then re-provision via
+  `provision-missing`.
+- **Names must match for linking.** `link-partners` matches on **partner name**. If the
+  same partner is spelled differently in messmass and the Camera app, it won't auto-link;
+  fix the name or link it manually.
+- **Silent skip is by design.** If provisioning "did nothing", the first thing to check is
+  whether `CAMERA_BASE_URL` and `CAMERA_MESSMASS_INTERNAL_SECRET` are both set. With either
+  missing, every provisioning call short-circuits with `camera_not_configured` and no error
+  surfaces in the UI.
+- **The Camera app is downstream.** Editing an organisation, partner, or event name in
+  messmass after provisioning does not automatically rename it in the Camera app — the
+  automatic path only ensures records *exist* and stamps IDs. Treat post-provision renames
+  as a manual reconciliation if the Camera app needs them.
+- **Two tokens, two directions.** Keep them straight: the Camera secret is outbound
+  (messmass → Camera app); the integration token guards the inbound ops endpoints.
+- **Don't confuse products.** "Camera" here is seyu's selfie-capture app. It is not the
+  messmass Clicker, not KYC variables, and not the content library — those never leave
+  messmass.
+
+## How it connects
+
+- **[Organisations](guides-tutorial-organisations.md)** — the top of the chain. An
+  organisation's Camera ID is stored as `cameraOrganizationId` when one of its partners or
+  events is first provisioned.
+- **[Partners](guides-tutorial-partners.md)** — a partner is the required link between an
+  event and its Camera event; its Camera ID lives in `cameraPartnerId`.
+- **[Events](guides-tutorial-events.md)** — creating an event is what triggers
+  provisioning; the resulting Camera IDs are stored in `externalRefs.camera`.
+- **[Fanmass](guides-tutorial-fanmass.md)** — the companion integration. The Camera app
+  captures the photos; Fanmass analyses them. Both surfaces share the same
+  `FANMASS_INTEGRATION_TOKEN` for their operator/ingest endpoints.
+
+## Screenshots
+_Screenshots to be added._
+
+## Related tutorials
+
+- [Getting started](guides-tutorial-getting-started.md)
+- [Organisations](guides-tutorial-organisations.md)
+- [Partners](guides-tutorial-partners.md)
+- [Events](guides-tutorial-events.md)
+- [Fanmass integration](guides-tutorial-fanmass.md)
+- [Collecting data](guides-tutorial-collecting-data.md)

--- a/docs/guides/guides-tutorial-charts-formulas.md
+++ b/docs/guides/guides-tutorial-charts-formulas.md
@@ -1,0 +1,122 @@
+# Tutorial: Charts & formulas
+Status: Active
+Last Updated: 2026-07-20T00:00:00.000Z
+Canonical: Yes
+Owner: Documentation
+
+> Audience: Internal operators & admins (report builders) · Prerequisites: Admin sign-in; variables defined in KYC · Related: [Variables (KYC)](guides-tutorial-variables-kyc.md) · [Content Library](guides-tutorial-content-library.md) · [Reports](guides-tutorial-reports.md)
+
+## What it is & why it matters
+A **chart** (messmass calls these the "chart algorithms") turns an event's raw stats into something a reader can see — a pie split, a KPI number, a bar breakdown, a block of text, an image, or a table. The **Chart Algorithm Manager** at `/admin/charts` (titled **📊 Chart Algorithm Manager** — "Configure chart algorithms, data processing & visualization settings") is where you build and maintain them.
+
+The engine of every chart is the **formula**. Each chart is made of one or more **elements**, and each element has a **label**, a **color**, and a formula that references variables by `[token]`. Because a variable's KYC name *is* its token, `[female] + [male]` sums exactly those two stats. Formulas let you compute derived values — totals, ratios, percentages, marketing multipliers — without touching the underlying data.
+
+Charts are defined once here, then placed onto reports through report data blocks (a chart can also be attached to a clicker group as a KPI header). Define the maths once; reuse the chart everywhere.
+
+## Before you start
+- Sign in as an admin and open `/admin/charts`.
+- The variables you plan to reference must exist in [KYC](guides-tutorial-variables-kyc.md). The manager loads the full variable catalog and validates your formulas against it — an unknown variable is flagged, not silently accepted.
+- Know the element-count rule for each type (below) — it is enforced when you save.
+
+## Step by step
+
+### 1. Understand chart types and their element counts
+When you create or edit a chart you choose a **Type**, and each type requires an exact number of elements:
+
+| Type | Elements | What it shows |
+|---|---|---|
+| **KPI** | 1 | A single headline number |
+| **Text** | 1 | A formatted text block (markdown) |
+| **Image** | 1 | A full-width image |
+| **Table** | 1 | A markdown table |
+| **Value Chain** | 2 | An icon + a title element + a description element |
+| **Pie** | 2 | Two segments |
+| **Bar** | 5 | Five bars |
+
+Switching type auto-adjusts the element list to the required count.
+
+### 2. Create a chart
+Click **New Chart** (➕). In the editor:
+- **Chart ID** — a stable slug, e.g. `gender-distribution` (used to reference the chart elsewhere).
+- **Title** — display heading, e.g. `Gender Distribution`.
+- **Type** — pick from the table above.
+- **Order** — position in the admin list (integer ≥ 1).
+
+### 3. Write element formulas
+For each element set a **label**, a **color**, and a **formula**. Formulas reference values with bracket tokens:
+- `[VAR]` — a KYC variable, e.g. `[female]`, `[remoteImages] + [selfies]`.
+- `[MEDIA:slug]` / `[TEXT:slug]` — an image or text asset from the [Content Library](guides-tutorial-content-library.md).
+- `[PARAM:key]` — a per-element parameter (a tunable multiplier or constant defined on the element, so you don't hardcode magic numbers in the formula).
+- `[MANUAL:key]` — a manually supplied aggregated value.
+- `[fanmass.x]` — a Fanmass analytics variable (nested tokens are permitted), e.g. `[fanmass.peopleCount]`, provided that variable exists in KYC.
+
+As you type, each formula is validated live against the KYC catalog and test-evaluated with sample data, so you get an immediate result or an "Unknown variables: …" error.
+
+Use the variable picker to insert a `[token]` rather than typing it, to avoid typos.
+
+### 4. Set formatting and display options
+- **Element formatting** (KPI/pie/bar) — toggle **Rounded** (whole numbers vs two decimals), **Show Prefix** (e.g. `€`), and **Show Suffix** (e.g. `%`). These control how numbers render.
+- **Display settings** — **Show Title**, an optional **Icon** (a Google Material Icon name such as `analytics` or `trending_up`, with an Outlined/Rounded variant), and a **Show Subtitle** toggle with its text.
+- **Pie extras** — **Show Percentages in Legend** toggles "Label: 25%" vs just "Label".
+- **Text extras** — a **Markdown Preset**: Standard, Compact, Hero, or Callout.
+- **Image / Text aspect ratio** — Landscape (16:9), Portrait (9:16), or Square (1:1); this drives the chart's grid width in the report layout.
+- **showTotal / total label** (bar) — show a total above the bars with a custom label.
+
+### 5. Save, or Update-and-keep-editing
+The editor offers two actions:
+- **Update** — saves and keeps the modal open, refreshing the form with the stored values so you can iterate rapidly and watch the save-status indicator.
+- **Save** — saves and closes.
+
+Validation runs first: Chart ID and Title are required, the element count must match the type, every element needs a label and a formula, and no formula may be invalid.
+
+### 6. Manage existing charts
+From the charts table you can:
+- **Search** by title, ID, or type; **sort** by title, type, or order (click a column header).
+- **Activate / deactivate** — the Status button toggles **✅ Active** / **❌ Inactive**. Only active charts are offered when attaching a chart to a clicker group.
+- **Reorder** — charts carry an `order`; adjust it to change position.
+- **Edit** / **Delete** — Delete asks for confirmation.
+
+### 7. Validate everything and refresh variables
+- **Validate All** — checks every formula across every chart and reports total/valid/error/warning counts, listing any errors by chart and element.
+- **Refresh Variables** (🔄) — forces the KYC variable cache to refresh so a newly created variable is recognised by the validator.
+
+### 8. A worked example — a gender pie
+1. **New Chart** → Chart ID `gender-distribution`, Title `Gender Distribution`, Type **Pie** (2 elements).
+2. Element 1: label `Female`, colour `#ff6b9d`, formula `[female]`.
+3. Element 2: label `Male`, colour `#3b82f6`, formula `[male]`.
+4. Leave **Show Percentages in Legend** on so the legend reads "Female: 43%".
+5. **Update** to save and watch the live test result, then **Save** to close.
+6. Place the chart on a report block (see [Reports](guides-tutorial-reports.md)).
+
+For a computed KPI instead, a single-element KPI chart with formula `[merched] / [totalFans] * 100`, a `%` suffix, and **Rounded** on gives a clean "merch penetration" headline.
+
+## Managing it
+**Placing a chart on a report.** A chart is a definition; it appears on a report when a report data block references it. Report layout and blocks are covered in [Reports](guides-tutorial-reports.md) and the [Reporting & Builder feature guide](../features/features-reporting-builder.md). A chart can also head a clicker group as a KPI — see [Clicker sets](guides-tutorial-clicker-sets.md).
+
+**Presets and icons.** Icons come from Google Material Icons (browse at fonts.google.com/icons) and are referenced by name plus an Outlined/Rounded variant. Text-chart presets change the visual treatment (fonts, padding, borders) without changing the content.
+
+**Content charts (text / image / table).** These use one element whose formula is typically a single reference — a report-content field like `reportText1` / `reportImage1`, or a Content Library token `[TEXT:slug]` / `[MEDIA:slug]`. Table charts render a markdown table stored in a `textarea` variable; the [Table Chart Usage Guide](../charts/charts-table-chart-usage-guide.md) walks through wiring one end to end.
+
+## Gotchas & good practice
+- **Token = KYC name.** `[female]` only resolves because a variable named `female` exists. A bracketed name with no matching variable is flagged as unknown and evaluates as missing (a common cause of "my chart shows 0").
+- **Element count is strict.** Pie needs exactly 2 elements, bar exactly 5, KPI/text/image/table exactly 1, value chain exactly 2. Changing type re-shapes the element list for you.
+- **Prefer the picker.** Insert variables from the picker to avoid typos and to see categories (including Bitly, SportsDB, Fanmass, and other integration variables).
+- **Refresh after adding a KYC variable.** The validator uses a cached catalog; click **Refresh Variables** if a brand-new variable is reported as unknown.
+- **Run Validate All before a release.** It surfaces every broken formula in one pass, which is far faster than opening charts one by one.
+- **Deactivate rather than delete** a chart you might reuse — deletion is permanent, and a chart referenced by a report or group will break if it disappears.
+
+## How it connects
+- **Inputs:** every `[token]` maps to a variable in [Variables (KYC)](guides-tutorial-variables-kyc.md), fed by [Collecting data](guides-tutorial-collecting-data.md).
+- **Content tokens:** `[MEDIA:slug]` / `[TEXT:slug]` come from the [Content Library](guides-tutorial-content-library.md).
+- **Output:** charts are placed into report blocks — see [Reports](guides-tutorial-reports.md) and the [Reporting & Builder feature guide](../features/features-reporting-builder.md).
+- **Reference docs:** [Charts overview](../charts/charts-overview.md) and the [Table Chart Usage Guide](../charts/charts-table-chart-usage-guide.md).
+
+## Screenshots
+_Screenshots to be added._
+
+## Related tutorials
+- [Variables (KYC)](guides-tutorial-variables-kyc.md)
+- [Content Library (images & text)](guides-tutorial-content-library.md)
+- [Clicker sets & variable groups](guides-tutorial-clicker-sets.md)
+- [Reports](guides-tutorial-reports.md)
+- [Collecting event data](guides-tutorial-collecting-data.md)

--- a/docs/guides/guides-tutorial-clicker-sets.md
+++ b/docs/guides/guides-tutorial-clicker-sets.md
@@ -1,0 +1,116 @@
+# Tutorial: Clicker sets & variable groups
+Status: Active
+Last Updated: 2026-07-20T00:00:00.000Z
+Canonical: Yes
+Owner: Documentation
+
+> Audience: Internal operators & admins · Prerequisites: Admin sign-in; variables already exist in KYC · Related: [Variables (KYC)](guides-tutorial-variables-kyc.md) · [Collecting data](guides-tutorial-collecting-data.md) · [Partners](guides-tutorial-partners.md)
+
+## What it is & why it matters
+A **clicker set** is a named layout of the data-entry screen. It decides which counters appear in the `/edit/{editSlug}` editor, how they are grouped, and in what order. The **Clicker Sets** page at `/admin/clicker-manager` (titled **↔️ Clicker Sets** — "Configure reusable clicker layouts, variable groups, and editor ordering") is where you build and maintain them.
+
+Why sets exist: different partners count different things. One partner may only track images and fans; another needs full merchandise and value-proposition breakdowns. Rather than force one universal layout, you build a clicker set per need and **assign it to a partner**. Every event under that partner inherits the layout. If a partner has no set assigned, the editor falls back to the built-in **Default Clicker**.
+
+The editor does not hard-code its layout — it renders exactly what the assigned set's variable groups describe. Reorder a group here and the counters move in the editor, with no code change.
+
+## Before you start
+- Sign in as an admin and open `/admin/clicker-manager`.
+- The variables you want to place must already exist in [KYC](guides-tutorial-variables-kyc.md) **and be flagged "Visible in Clicker"** — only clicker-visible variables are offered when you build a group.
+- Decide which clicker set you are editing. The page always works against **one selected set** (persisted in your browser), shown in the **🎮 Clicker Set** selector card.
+
+## Step by step
+
+### 1. Pick or create a clicker set
+The **🎮 Clicker Set** card ("Select which clicker layout to edit — partner-assignable") holds the set selector and its controls:
+- **➕ New Set** — name it (e.g. "Partner A Clicker"). New sets start **empty**; tick **Clone groups from currently selected set** to copy the current layout as a starting point.
+- **✏️ Rename** — rename the selected set.
+- **⭐ Make Default** — mark this set as the fallback (Default) layout.
+- **🗑️ Delete** — remove the selected set (you cannot delete the current Default).
+
+The dropdown shows each set, a ⭐ on the default, and a partner count (e.g. "(3 partners)") where assigned.
+
+### 2. Seed a starting layout (optional)
+On an empty set, click **Seed Defaults** (or the **🌱 Seed Default Groups** button on the empty-state card) to create the standard eight-group layout:
+
+1. Images taken — `remoteImages`, `hostessImages`, `selfies` (with an attached "all images" KPI chart)
+2. Fans — `remoteFans`, `stadium`
+3. Gender — `female`, `male`
+4. Generations — `genAlpha`, `genYZ`, `genX`, `boomer`
+5. Merchandise — `merched`, `jersey`, `scarf`, `flags`, `baseballCap`, `other`
+6. Image approval — `approvedImages`, `rejectedImages`
+7. Visits & value proposition — `visitQrCode`, `visitShortUrl`, `socialVisit`, `visitWeb`, `eventValuePropositionVisited`, `eventValuePropositionPurchases`
+8. Event outcome — `eventAttendees`, `eventResultHome`, `eventResultVisitor`
+
+Seeding only runs when the selected set has no groups, so it never clobbers an existing layout.
+
+### 3. Add a variable group
+Click **New Group** (enabled once a set is selected). In the group form:
+- **Group Order** — a number; groups render top-to-bottom by this order.
+- **Chart Algorithm (optional)** — attach a KPI/chart to head the group. Search by name or ID and pick from the dropdown; ✅ marks active charts, ❌ inactive.
+- **Title Override (optional)** — a heading for the group (e.g. "Images").
+- **Visibility in Edit Modes** — **↔️ Show in Clicker Mode** and **✏️ Show in Manual Mode**. A group can appear in one mode but not the other.
+- **Variables in Group** — search the **Add Variables** list (only clicker-visible variables appear), click **+ Add**, and reorder with the **↑ / ↓** buttons or remove with **✕**. The order here is the order counters appear.
+
+A non-special group must have at least one variable. Click **Save Group**.
+
+### 4. Add the special "Report Content" group
+Click **Add Report Content** (the 📦 button). This inserts a group with `specialType: 'report-content'` and the title **📦 Report Content**. It carries no counters — it is a placeholder that controls the report-content block in the editor's Builder mode, where operators fill report text, tables, and images. It shows a purple **📦 Report Content** badge instead of a variable count.
+
+### 5. Edit, reorder, and delete groups
+Each group card shows its order, title, either a variable count or the Report Content badge, and an attached-chart badge (📊 chart-id) if one is set. From a card you can:
+- toggle its **↔️ Clicker** / **Manual** visibility checkboxes inline,
+- **Edit** to reopen the full group form,
+- **Delete** (with confirmation) to remove just that group.
+Reordering is done by editing a group's **Group Order** number.
+
+### 6. Housekeeping
+- **Refresh Variables** (🔄) — forces the shared KYC variable cache to refresh, so a variable you just created in KYC becomes available to add here.
+- **Delete All** — removes every group in the **currently selected set only** (with confirmation). It resets that set's layout; other sets are untouched.
+
+### 7. Assign the set to a partner
+A layout only reaches an event through its partner. On the [Partners](guides-tutorial-partners.md) edit form, choose this clicker set. Events under that partner then render its layout in the editor. Leave a partner's set unassigned and its events use the Default Clicker.
+
+### 8. A worked example — a stripped-down partner layout
+A partner only tracks images and attendance and finds the full default overwhelming:
+1. Select their set (or **➕ New Set** "Partner A Clicker" — you can clone from the default to start).
+2. **Delete All** the groups you don't need, or start empty.
+3. **New Group** — order 1, title "Images", add `remoteImages`, `hostessImages`, `selfies`, both modes visible.
+4. **New Group** — order 2, title "Attendance", add `eventAttendees`, both modes visible.
+5. **Add Report Content** so operators can still fill the report's text/images in Builder mode.
+6. On the [Partners](guides-tutorial-partners.md) form, assign "Partner A Clicker" to the partner.
+
+Every event under that partner now shows just two counter groups plus the report-content block — no merchandise, no generations, no clutter.
+
+## Managing it
+**One set, one selection.** The page edits exactly one set at a time; your selection is remembered in the browser. All group create/edit/delete operations are scoped to that set — there is no accidental cross-set editing.
+
+**Groups vs variables.** A **variable group** owns three things: an order, an ordered list of variable names, and per-mode visibility. It optionally owns a title override and an attached chart. The variables themselves (their type, label, and clicker/manual flags) still live in [KYC](guides-tutorial-variables-kyc.md) — a group only *references* them by name.
+
+**Missing variables.** If a group lists a variable name that no longer exists (deleted or renamed in KYC), the card shows a yellow "N missing" badge. Fix it by editing the group and removing or replacing the stale entry.
+
+**What the editor does with all this.** In `/edit/{editSlug}`, the editor loads the event's partner clicker set, then renders its groups by order, then the variables inside each group by list order, filtered by the per-mode visibility flags. That full chain is described in [Collecting data](guides-tutorial-collecting-data.md).
+
+## Gotchas & good practice
+- **Only clicker-visible variables can be added.** If a variable you want isn't in the **Add Variables** list, set its **Visible in Clicker** flag in [KYC](guides-tutorial-variables-kyc.md) first, then click **Refresh Variables**.
+- **New sets are empty on purpose.** Either **Seed Defaults** or clone from an existing set — otherwise the partner's editor falls back to Default with a warning banner.
+- **Delete All is per-set, not global.** It only clears the selected set. That is deliberate, but double-check which set is selected before confirming.
+- **Report Content is a control, not a counter.** It has no variables; it exists to switch on the report-content block for Builder mode.
+- **Reordering is by number.** To move a group, change its Group Order; to move a counter within a group, use the ↑/↓ controls in the group form.
+- **Assign before you expect results.** Building a set does nothing until a partner points at it.
+
+## How it connects
+- **The dictionary:** groups reference variables defined in [Variables (KYC)](guides-tutorial-variables-kyc.md).
+- **The entry screen:** the assigned set drives what operators see in [Collecting data](guides-tutorial-collecting-data.md).
+- **The assignment:** sets are attached to partners — see [Partners](guides-tutorial-partners.md).
+- **Attached charts:** the optional group chart comes from [Charts & formulas](guides-tutorial-charts-formulas.md).
+- **Admin reference:** deeper notes live in [../admin/admin-clicker-manager.md](../admin/admin-clicker-manager.md).
+
+## Screenshots
+_Screenshots to be added._
+
+## Related tutorials
+- [Variables (KYC)](guides-tutorial-variables-kyc.md)
+- [Collecting event data](guides-tutorial-collecting-data.md)
+- [Partners](guides-tutorial-partners.md)
+- [Charts & formulas](guides-tutorial-charts-formulas.md)
+- [Reports](guides-tutorial-reports.md)

--- a/docs/guides/guides-tutorial-collecting-data.md
+++ b/docs/guides/guides-tutorial-collecting-data.md
@@ -1,0 +1,120 @@
+# Tutorial: Collecting event data (Clicker & Manual)
+Status: Active
+Last Updated: 2026-07-20T00:00:00.000Z
+Canonical: Yes
+Owner: Documentation
+
+> Audience: Internal operators & implementation partners (partners can self-serve data entry via a shared link) · Prerequisites: An event already exists (see Events); the edit link or an admin sign-in · Related: [Events](guides-tutorial-events.md) · [Variables (KYC)](guides-tutorial-variables-kyc.md) · [Clicker sets](guides-tutorial-clicker-sets.md) · [Sharing & access](guides-tutorial-sharing-access.md)
+
+## What it is & why it matters
+Every chart on a report is fed by the event's `stats{}` — the numbers and text captured during and after an activation. This tutorial covers how those stats get in, and the single most important rule: **the different data sources never overwrite each other.**
+
+There are **three ways stats enter an event**:
+
+1. **The Editor (Clicker / Manual / Builder)** at `/edit/{editSlug}` — hands-on counting and typing.
+2. **Google Sheets sync** — pull/push numbers from a connected sheet.
+3. **Fanmass** — image/person/brand analytics synced into dedicated variables.
+
+Each source writes to its own variables, so counting attendees in the clicker will not be clobbered by a Fanmass sync, and a Google Sheets pull will not wipe your clicker totals. Understanding which source owns which variable keeps your data clean.
+
+| Source | Where you use it | Typical variables it owns |
+|---|---|---|
+| Clicker / Manual editor | `/edit/{editSlug}` | Core counts — images, fans, gender, generations, merch, visits, event outcome |
+| Google Sheets | Editor sync (pull/push) | Whatever the connected sheet maps to |
+| Fanmass | `/admin/events` → Fanmass Sync | `[fanmass.*]` and `[fanmass*]` analytics variables |
+
+## Before you start
+- Get into the editor one of two ways:
+  - **As an admin:** sign in, open the event from `/admin/events`, and choose **Open Editor** (or navigate to `/edit/{editSlug}`). Signed-in admins skip the password prompt.
+  - **As a partner / field operator:** open the **edit link** you were given and enter the **page password** when prompted (see the sharing section below). No admin account needed.
+- Know your event's clicker set. Which counters appear, and in what order, is decided by the event's partner **clicker set** and the admin-defined **variable groups** — not by the editor itself.
+
+## Step by step
+
+### 1. Open the editor and pick a mode
+At `/edit/{editSlug}` the **EditorDashboard** loads. One button cycles through three modes:
+
+- **🖱️ Clicker** — tap/click a counter card to increment it by one. Built for live counting on a phone or tablet during the activation.
+- **✏️ Manual** — type exact numbers into each field. Values save automatically when you leave a field (on blur); a **Save** button is also shown.
+- **🏗️ Builder** — shows the report template's layout and, for each chart block, the inputs that feed that chart (numbers, text areas, image uploads). Use this to fill report-specific content in context. A **Save** button is shown here too.
+
+Clicker and Manual show the **same variables** — the difference is only how you enter them (tap to count vs. type a number).
+
+### 2. Enter the core counts (Clicker)
+In **Clicker** mode you will see grouped cards such as images taken, fans, gender split, generations, merchandise, image approval, visits, and event outcome. Tap a card each time you observe that thing. The running total updates immediately. Because clicker increments are per-tap, this mode is designed to be used live rather than reconciled afterwards.
+
+### 3. Correct or bulk-enter numbers (Manual)
+Switch to **Manual** to type exact figures — useful when you already have totals (e.g. official attendance) or need to fix a mis-tap. Enter the number and click away; it saves on blur. Use **Save** to confirm.
+
+### 4. Fill report content (Builder)
+Switch to **Builder** when you need to populate the text, tables, and images that appear on the report — the inputs are grouped by the chart they feed, so you fill exactly what each block needs. See [Reports](guides-tutorial-reports.md) and the [Reporting & Builder feature guide](../features/features-reporting-builder.md) for how these map to charts.
+
+### 5. Sync from Google Sheets (optional)
+If the event is connected to a Google Sheet, the editor exposes an event-level sync (pull/push). Use it to bring spreadsheet-maintained numbers into the event or push the event's numbers out. See [Google Sheets](guides-tutorial-google-sheets.md) and the [Google Sheets integration feature guide](../features/features-google-sheets-integration.md).
+
+### 6. Sync Fanmass analytics (optional)
+From `/admin/events`, the per-event **Fanmass Sync** action links a Fanmass batch and imports its analytics into the event. Fanmass writes to its **own** variables — nested ones like `[fanmass.peopleCount]`, `[fanmass.projectedReach]`, `[fanmass.brands]`, and flat ones like `[fanmassPeopleCount]`, `[fanmassProjectedReach]`, `[fanmassTopBrandName]` — so it never overwrites clicker or manual stats. See [Fanmass](guides-tutorial-fanmass.md).
+
+## Managing it
+**How clicker sets and variable groups decide what you see.**
+
+The editor does not hard-code its layout. It renders from **variable groups** (admin-defined) that belong to a **clicker set**:
+
+- A **clicker set** is a named collection of variable groups. Each partner can be assigned a clicker set; the event inherits it from its Partner 1 (or Partner 2). If a partner has no clicker set, the editor falls back to the **Default Clicker** layout and shows a banner: "Using default clicker layout because the partner's assigned clicker set is missing. Please update the partner's clicker set in Admin."
+- A **variable group** has a **group order**, a list of **variables in order**, and visibility flags **visible in clicker** and **visible in manual**. Groups render top-to-bottom by group order, and within a group the counters appear in the order the variables are listed.
+- Individual variables also carry flags — **visible in clicker** and **editable in manual** — so an admin can show a variable in one mode but not the other.
+
+So the answer to "which counters appear and in what order" is always: the assigned clicker set → its variable groups (by group order) → the variables inside each group (in list order), filtered by the per-mode visibility flags.
+
+**A concrete example.** A freshly seeded Default Clicker lays out groups roughly like this:
+
+1. Images taken — `remoteImages`, `hostessImages`, `selfies`
+2. Fans — `remoteFans`, `stadium`
+3. Gender — `female`, `male`
+4. Generations — `genAlpha`, `genYZ`, `genX`, `boomer`
+5. Merchandise — `merched`, `jersey`, `scarf`, `flags`, `baseballCap`, `other`
+6. Image approval — `approvedImages`, `rejectedImages`
+7. Visits & value proposition — `visitQrCode`, `visitShortUrl`, `socialVisit`, `visitWeb`, and so on
+8. Event outcome — `eventAttendees`, `eventResultHome`, `eventResultVisitor`
+
+Reorder a group or move a variable within it in Admin, and the editor's counters move with it — no code change and no per-event fiddling.
+
+If the editor shows **"No groups configured — Go to Admin → KYC Variables to configure variable groups"**, an admin needs to set up groups at `/admin/variables`. See [Variables (KYC)](guides-tutorial-variables-kyc.md) and [Clicker sets](guides-tutorial-clicker-sets.md).
+
+**Sharing the edit page with a partner (self-service data entry).**
+
+Partners can enter their own data without an admin account:
+
+1. From `/admin/events`, open the event's **Share Edit Page** action. The Share popup generates a **shareable URL** for `/edit/{editSlug}` plus a **page password**.
+2. Send the partner the **URL and the password separately** (the popup even suggests this for security).
+3. The partner opens the link, enters the password once, and lands directly in the editor. Their session is remembered for **24 hours**, after which they re-enter the password.
+4. Signed-in admins never see the prompt — they bypass it automatically.
+
+Full details, page types, and session behaviour are in [Sharing reports & access control](guides-tutorial-sharing-access.md).
+
+## Gotchas & good practice
+- **Sources are additive, not competitive:** clicker, manual, Google Sheets, and Fanmass each own their variables. Re-syncing Fanmass will not reset your clicker attendance, and a sheet pull will not erase manual edits. If a number "disappeared," check whether you were looking at a different variable, not an overwrite.
+- **Clicker is for live counting; Manual is for reconciliation:** don't try to "fix" a live-count discrepancy by tapping backwards — switch to Manual and type the correct total.
+- **Manual saves on blur:** click out of the field (or use Save) to persist. Navigating away mid-edit before blur can drop the last value.
+- **Empty editor? It's configuration, not a bug:** "No groups configured" means an admin must set up variable groups at `/admin/variables`. The fallback banner means the partner's clicker set is missing and the default layout is standing in.
+- **Order is admin-controlled:** if operators want counters reordered, that's a change to the variable group order in Admin, not something you fix per-event.
+- **Share the password out-of-band:** send the edit URL and its page password through separate channels so a single leaked message can't unlock editing.
+
+## How it connects
+- **Events:** the editor edits one event's `stats{}` — see [Events](guides-tutorial-events.md).
+- **What appears in the editor:** driven by [Variables (KYC)](guides-tutorial-variables-kyc.md) and [Clicker sets](guides-tutorial-clicker-sets.md).
+- **What the numbers become:** charts and formulas on the report — see [Charts & formulas](guides-tutorial-charts-formulas.md) and [Reports](guides-tutorial-reports.md).
+- **Other inbound sources:** [Google Sheets](guides-tutorial-google-sheets.md) and [Fanmass](guides-tutorial-fanmass.md).
+- **Letting partners in:** [Sharing reports & access control](guides-tutorial-sharing-access.md).
+
+## Screenshots
+_Screenshots to be added._
+
+## Related tutorials
+- [Events](guides-tutorial-events.md)
+- [Variables (KYC)](guides-tutorial-variables-kyc.md)
+- [Clicker sets](guides-tutorial-clicker-sets.md)
+- [Charts & formulas](guides-tutorial-charts-formulas.md)
+- [Google Sheets](guides-tutorial-google-sheets.md)
+- [Fanmass](guides-tutorial-fanmass.md)
+- [Sharing reports & access control](guides-tutorial-sharing-access.md)

--- a/docs/guides/guides-tutorial-content-library.md
+++ b/docs/guides/guides-tutorial-content-library.md
@@ -1,0 +1,104 @@
+# Tutorial: Content Library (images & text)
+Status: Active
+Last Updated: 2026-07-20T00:00:00.000Z
+Canonical: Yes
+Owner: Documentation
+
+> Audience: Internal operators & admins · Prerequisites: Admin sign-in · Related: [Charts & formulas](guides-tutorial-charts-formulas.md) · [Variables (KYC)](guides-tutorial-variables-kyc.md) · [Reports](guides-tutorial-reports.md)
+
+## What it is & why it matters
+The **Content Library** at `/admin/content-library` (titled **📚 Content Library** — "Define image and text variables for event-specific content") is where you manage the non-numeric content that appears on reports: images (logos, photos, sponsor artwork) and text blocks (executive summaries, captions, markdown tables).
+
+Every asset gets a **slug**, and that slug becomes a reference **token** you drop into a chart formula — `[MEDIA:slug]` for an image, `[TEXT:slug]` for text. Instead of hardcoding a URL or a paragraph into a chart, you reference the library entry by token. Update the library entry once and every chart that references it updates too.
+
+The library supports two modes that solve two different problems:
+
+| Mode | What it is | Use it for | Content at creation |
+|---|---|---|---|
+| **📋 Variable Definition** | A field filled per-event in the editor's Builder/Manual mode | Content that changes every activation ("Event Photo 1") | Optional — filled later per project |
+| **🌐 Global Asset** | Reusable content shared across all projects | A company logo, a boilerplate disclaimer | Required — uploaded/entered now |
+
+Both produce the same kind of token; the difference is *when and where* the actual content is supplied.
+
+## Before you start
+- Sign in as an admin and open `/admin/content-library`.
+- Decide the mode for what you're creating: is this a per-event slot to be filled later (Variable Definition), or fixed content reused everywhere (Global Asset)?
+- Have your image ready to upload (for image assets) or your text/markdown ready to paste (for text assets) if you're creating a Global Asset — content is required in that mode.
+
+## Step by step
+
+### 1. Browse and filter the library
+Each asset is a card showing a preview (image thumbnail or text snippet), its **title**, an **Image / Text** badge, its reference **token** as a code chip, its category and tags, and — if referenced — a **Used in N charts** badge. The hero shows a **Variable Registry** badge and a live count of variables.
+
+Narrow the list with:
+- the hero **search** (matches title, description, slug, tags),
+- **Type** (All / 🖼️ Images / 📝 Text),
+- **Category** (built from your assets),
+- **Sort By** (Date Created / Title / Usage Count) and **Order** (Descending / Ascending).
+
+### 2. Create an image asset
+Click **📷 New Image Variable**. In the modal:
+1. Choose the mode — **📋 Variable Definition** (define the field, upload the actual image per-project in Manual Edit) or **🌐 Global Asset** (upload a reusable image now).
+2. **Title** — e.g. `Event Photo 1` or `{messmass} Logo`.
+3. **Slug** — auto-generated from the title (e.g. `event-photo-1`); editable.
+4. **Description** (optional, aids search).
+5. **Category** and **Tags** (type a tag, press Enter or **Add**; click a tag to remove it).
+6. **Aspect Ratio** — 16:9 (Landscape), 1:1 (Square), or 9:16 (Portrait).
+7. **Upload Image** — required for a Global Asset; optional for a Variable Definition (the field is filled per-project later).
+
+Click **Create Variable**.
+
+### 3. Create a text asset
+Click **📝 New Text Variable**. The flow mirrors images: pick the mode, set title/slug/description/category/tags, then enter **Text Content** (markdown supported). Content is required for a Global Asset and optional for a Variable Definition. A character counter is shown.
+
+### 4. Copy the reference token
+Every card has a **Copy Token** button. It copies the exact token to your clipboard — `[MEDIA:slug]` for images, `[TEXT:slug]` for text — ready to paste into a [chart formula](guides-tutorial-charts-formulas.md). The token is also shown on the card as a code chip.
+
+### 5. Edit an asset
+Click **Edit** to change the title, description, category, tags, image/aspect ratio, or text content. If you change the **slug**, the modal warns you: existing chart references to the old token will break. If the asset is already used, the modal also notes how many charts reference it.
+
+### 6. Check usage and delete safely
+- Click the **Used in N charts** badge (or **Delete**) to see exactly which charts reference the asset — each listed with its title, chart ID, and type.
+- A plain **Delete** on an unused asset asks for confirmation and removes it.
+- If the asset **is** in use, deletion is blocked and the **⚠️ Asset In Use** dialog lists the affected charts. You can proceed with **Force Delete Anyway** — but doing so will break those charts, so fix or repoint them first.
+
+### 7. A worked example
+To put a sponsor logo on every report and a per-event hero photo on each one:
+1. Create a **🌐 Global Asset** image titled `Sponsor Logo`, slug `sponsor-logo`, and upload the artwork. Its token becomes `[MEDIA:sponsor-logo]`.
+2. Create a **📋 Variable Definition** image titled `Hero Photo`, slug `hero-photo`, no upload yet. Its token becomes `[MEDIA:hero-photo]`.
+3. In [Charts & formulas](guides-tutorial-charts-formulas.md), build two image charts: one whose element formula is `[MEDIA:sponsor-logo]`, one whose formula is `[MEDIA:hero-photo]`.
+4. Place both charts on the report. The sponsor logo shows everywhere immediately; the hero photo shows once each event's operator uploads it in Builder/Manual mode.
+5. Update the sponsor artwork later by editing the one Global Asset — every report refreshes without touching a single chart.
+
+## Managing it
+**Variable Definition vs Global Asset — which to choose.** Use a **Variable Definition** when each event supplies its own value (the library defines the *slot*; operators fill the image or text per-project in the editor's Builder/Manual mode). Use a **Global Asset** when the content is the same everywhere (a logo, a boilerplate disclaimer) and you want to store it once and reference it by token from any chart.
+
+**Slugs are the contract.** A slug is the stable identifier a token points at. Slugs are lowercase and URL-safe (kebab-case such as `partner-abc-logo`, or a `stats.camelCase` field name). Because tokens embed the slug, renaming a slug orphans every chart that referenced the old one — the edit modal warns you precisely for this reason.
+
+**Usage tracking is automatic.** The library counts how many charts reference each asset and exposes it as the **Used in N charts** badge and the usage dialog. This is your safety net before deleting.
+
+**Slug rules and auto-generation.** When you type a title, the slug is auto-suggested by lowercasing it, stripping punctuation, and replacing spaces with hyphens (`Partner ABC Logo` → `partner-abc-logo`). You can override it. A valid slug is either kebab-case (`partner-abc-logo`) or a `stats.camelCase` field name (`stats.fanSelfiePortrait1`); the form rejects anything else.
+
+**Aspect ratio drives layout width.** For image and text assets the aspect ratio you pick (16:9 Landscape, 1:1 Square, 9:16 Portrait) determines how wide the content sits in the report grid. Choose the ratio that matches the artwork so it isn't letterboxed or cropped on the report.
+
+## Gotchas & good practice
+- **Don't rename slugs casually.** A slug change breaks existing `[MEDIA:slug]` / `[TEXT:slug]` references. If you must, update every referencing chart afterwards.
+- **Force Delete breaks charts.** The dialog lists exactly which ones — treat that list as a to-do, not a formality.
+- **Global content belongs in Global Assets.** Putting a shared logo in a per-event Variable Definition means re-uploading it for every event; store it once as a Global Asset and reference the token.
+- **Variable Definitions can be created empty.** That's intentional — you're defining the field now and filling content per-project later. Don't expect a preview until an event fills it.
+- **Tokens are case-specific prefixes.** Images use `MEDIA`, text uses `TEXT`. Use **Copy Token** rather than typing to avoid mistakes.
+- **Categorise and tag as you go.** The filters are only as useful as the metadata you enter.
+
+## How it connects
+- **Where tokens are used:** `[MEDIA:slug]` and `[TEXT:slug]` are referenced inside [Charts & formulas](guides-tutorial-charts-formulas.md), typically by image/text/table charts.
+- **Per-event content:** Variable Definitions are filled during [Collecting data](guides-tutorial-collecting-data.md) (Builder mode) and surface on [Reports](guides-tutorial-reports.md).
+- **The wider catalog:** numeric and short text variables live in [Variables (KYC)](guides-tutorial-variables-kyc.md); the Content Library focuses on images and longer text.
+
+## Screenshots
+_Screenshots to be added._
+
+## Related tutorials
+- [Charts & formulas](guides-tutorial-charts-formulas.md)
+- [Variables (KYC)](guides-tutorial-variables-kyc.md)
+- [Collecting event data](guides-tutorial-collecting-data.md)
+- [Reports](guides-tutorial-reports.md)

--- a/docs/guides/guides-tutorial-events.md
+++ b/docs/guides/guides-tutorial-events.md
@@ -1,0 +1,132 @@
+# Tutorial: Events
+Status: Active
+Last Updated: 2026-07-20T00:00:00.000Z
+Canonical: Yes
+Owner: Documentation
+
+> Audience: Internal operators & implementation partners · Prerequisites: An admin sign-in for `/admin`; a partner already exists if you want to attribute the event · Related: [Partners](guides-tutorial-partners.md) · [Collecting event data](guides-tutorial-collecting-data.md) · [Sharing & access](guides-tutorial-sharing-access.md)
+
+## What it is & why it matters
+In messmass, an **event is a "project"** — it is the single record that everything else hangs off. One event holds:
+
+- `eventName` — the human title (e.g. "Team A x Team B" or "Summer Launch Night").
+- `eventDate` — the date the activation happened.
+- `partner1` / `partner2` — the organiser (home team) and, for sports matches, the away team.
+- `hashtags` — free and categorised tags used later for filtering and roll-ups.
+- `stats{}` — the bag of numbers and text that feeds every chart on the report.
+
+Because the event is the master object, creating it correctly is what makes reporting, sharing, and downstream apps line up. When you create an event, messmass also generates its report and edit URLs and quietly provisions a matching event in the Camera app — so the same activation is represented everywhere without extra typing.
+
+## Before you start
+- You need to be **signed in as an admin**. Event management lives under `/admin`, which is protected — unauthenticated visitors are redirected to the login page.
+- Decide the event type first:
+  - **Single event** — one organiser. You must type an Event Name.
+  - **Sports match** — two partners. The name is auto-generated as `Partner 1 x Partner 2`, so you leave the name blank.
+- If you want partner branding and roll-ups, make sure the **partner(s) exist** before you create the event (see [Partners](guides-tutorial-partners.md)). You can also attach partners after creation.
+- Optionally know which **report style** (colour theme) and **report template** (layout) you want. Both are optional and changeable later.
+
+## Step by step
+
+### 1. Open the events workspace
+Go to **`/admin/events`**. The page is titled **"📅 Manage Events"** with the subtitle "Manage all events, statistics, and sharing options". You will see the list of existing events with search and sort.
+
+### 2. Start a new event
+Open the **Create Event** modal. Creation is a **two-step flow** shown as badges: **Basics → Reporting**.
+
+**Step 1 — Event Basics:**
+- **Event Name \*** — required for a single event.
+- **Event Date \*** — required.
+- **Hashtags** — optional; type to search existing tags or add new ones. You can add plain hashtags and categorised hashtags here.
+
+Click **Continue to Reporting**.
+
+**Step 2 — Reporting Defaults:**
+- **Report Visual Style** — the colour theme (a 26-colour system covering charts, hero, and text). Leave as "— Use Default Style —" if unsure. See [Report themes](guides-tutorial-report-themes.md).
+- **Report Template** — the report layout. Leave as "— Use Partner or Default Template —" to inherit the partner's template or the system default. See [Reports](guides-tutorial-reports.md).
+
+Click **Create Event**.
+
+> Note: The Create Event modal collects name, date, hashtags, and reporting defaults. Partner attribution (Partner 1 / Partner 2) is set from the **Edit** modal or from the partner assignment screen — see step 5.
+
+The new event starts with a **default `stats{}` bag** — every core counter (images, fans, gender split, generations, merchandise, image approval, visit sources, and event outcome fields) is initialised to `0`, ready for data entry. You do not fill any of these in the create modal; that happens in the editor afterwards.
+
+### 3. Use the "Event created" shortcuts
+After a successful create, a green **"Event created: <name>"** card appears with direct actions so you do not have to hunt through the admin:
+
+- **Open Editor** — jumps to `/edit/{editSlug}` to enter data (see [Collecting event data](guides-tutorial-collecting-data.md)).
+- **Open Report** — opens `/report/{viewSlug}`, the shareable report.
+- **Assign Partners** — opens `/admin/project-partners` to attach partners.
+- **Dismiss** — closes the card.
+
+### 4. Understand the two auto-generated slugs
+You never type these — messmass generates them at creation:
+
+- **View slug** → the report lives at **`/report/{viewSlug}`** (read-only).
+- **Edit slug** → the editor lives at **`/edit/{editSlug}`** (data entry).
+
+Both are **random UUIDs** (version-4). They are cryptographically random, not guessable, and each event gets its own unique pair. That unguessability is what protects the report — anyone with the link can view it, but the link cannot be guessed. (More on this in [Sharing & access](guides-tutorial-sharing-access.md).)
+
+### 5. Attribute partners (and make it a sports match)
+Open an existing event with **Edit**. This is also a two-step flow: **Basics → Reporting & Distribution**.
+
+In **Basics** you will find:
+- **Event UUID** — read-only, the permanent identifier assigned at creation.
+- **Partner 1 (Organizer / Home Team) \*** — required; pick the primary organiser or home team.
+- **Event Name** — shown when there is no Partner 2.
+- **Partner 2 (Away Team)** — optional. When you set both partners, the Event Name becomes **auto-generated** as `Partner 1 x Partner 2` and the name field turns read-only.
+- **Event Date \*.**
+
+In **Reporting & Distribution** you can adjust Hashtags, Report Visual Style, Report Template, and manage the event's Bitly links (see [Bitly](guides-tutorial-bitly.md)).
+
+> Note: When you set Partner 1, the event inherits that partner's clicker set for data entry and can inherit the partner's report template — this is why partner attribution matters for consistent reports.
+
+### 6. Camera app auto-provisioning (automatic)
+When an event is created, messmass **automatically provisions a matching event in the Camera app**. messmass is the master; the camera event mirrors the same partner/event and inherits the partner's default design.
+
+This is **fire-and-forget and non-blocking**: if camera provisioning fails or is slow, your event still creates successfully in messmass. You do not need to do anything for this to happen. See [Camera app](guides-tutorial-camera-app.md) for what the operator sees on the camera side.
+
+## Managing it
+- **Search** — use the "Search events..." box. Search runs on the server, so it covers all events, not just the ones on screen.
+- **Sort** — sort by event name, event date, images, fans, or attendees. Click a column to cycle ascending → descending → off.
+- **Load more** — the list pages in batches; use **"Load 20 More Events"** until you see "— All N events loaded —".
+- **Export CSV** — export a single event's variables (name, dates, and every stat) to a `.csv` for offline analysis.
+- **Quick Add** — the **"Quick Add 🤝 Sports Match"** button opens `/admin/quick-add`, a faster builder for match events and bulk import.
+- **Fanmass Sync** — a per-event action opens the Fanmass modal, where you link a Fanmass batch and sync its analytics into the event's variables (see [Fanmass](guides-tutorial-fanmass.md)).
+- **Delete** — removing an event deletes the project record. Treat this as permanent; export first if you might need the numbers.
+
+## Gotchas & good practice
+- **Name vs. auto-name:** if you attach two partners, stop typing a name — it will be overwritten by `Partner 1 x Partner 2`. For single events, the name is mandatory.
+- **Partner first, event second (ideally):** creating the partner before the event lets the event inherit the partner's clicker set and template, and gives cleaner roll-ups. You can still attach partners afterwards.
+- **Don't share the edit slug when you mean the report:** `/edit/...` is for data entry, `/report/...` is for viewing. Sending the wrong one either exposes editing or blocks viewing.
+- **Reporting defaults are optional:** leaving style and template blank is fine — the event falls back to the partner's or the system default. Set them explicitly only when you need a specific look.
+- **Camera provisioning is best-effort:** a missing camera event is not a create failure. If a camera event is expected but absent, re-check on the camera side rather than re-creating the messmass event.
+- **The Event UUID is permanent:** it never changes and is safe to quote in support tickets; the view/edit slugs are what you share externally.
+
+### How events roll up into partner and organisation reports
+An event is never an island — two fields decide where it aggregates:
+
+- **Partner attribution.** Once an event has a Partner 1 (and optionally Partner 2), it becomes part of that partner's activity. A **partner report** (`/partner-report/{slug}`) presents the partner's events together, so attributing the event correctly is what makes it show up in the partner's story.
+- **Organisation membership.** Partners belong to organisations, so an event attributed to a partner also feeds the **organisation report** (`/organization-report/{id}`), which aggregates across the organisation's partners and events.
+- **Hashtags.** The event's hashtags let it surface on **hashtag** and **filter** pages, which cut across events regardless of partner.
+
+The practical takeaway: the numbers you enter on one event automatically contribute to higher-level reports — but only along the partner/organisation/hashtag links you set on the event. An unattributed, untagged event will report on its own page and nowhere else.
+
+## How it connects
+- **Data entry:** the event's editor at `/edit/{editSlug}` is where operators (or partners with a link) fill `stats{}` — see [Collecting event data](guides-tutorial-collecting-data.md).
+- **Reports:** `stats{}` plus the assigned template and style render the report at `/report/{viewSlug}` — see [Reports](guides-tutorial-reports.md).
+- **Roll-ups:** an event's partner attribution and hashtags are what let it appear in **partner reports** and **organisation reports**, and in **hashtag/filter** pages — see [Organisations](guides-tutorial-organisations.md), [Partners](guides-tutorial-partners.md), and [Hashtags & filters](guides-tutorial-hashtags-filters.md).
+- **Distribution:** Bitly links attached to the event feed visit metrics back into the report — see [Bitly](guides-tutorial-bitly.md).
+- **Downstream apps:** creation mirrors the event into the Camera app — see [Camera app](guides-tutorial-camera-app.md).
+
+## Screenshots
+_Screenshots to be added._
+
+## Related tutorials
+- [Getting started](guides-tutorial-getting-started.md)
+- [Partners](guides-tutorial-partners.md)
+- [Organisations](guides-tutorial-organisations.md)
+- [Collecting event data (Clicker & Manual)](guides-tutorial-collecting-data.md)
+- [Reports](guides-tutorial-reports.md)
+- [Sharing reports & access control](guides-tutorial-sharing-access.md)
+- [Camera app](guides-tutorial-camera-app.md)
+- [Fanmass](guides-tutorial-fanmass.md)

--- a/docs/guides/guides-tutorial-fanmass.md
+++ b/docs/guides/guides-tutorial-fanmass.md
@@ -1,0 +1,251 @@
+# Tutorial: Fanmass integration
+Status: Active
+Last Updated: 2026-07-20T00:00:00.000Z
+Canonical: Yes
+Owner: Documentation
+
+> Audience: Operators + technical implementers · Prerequisites: You can create events and open the Events admin · Related: [Events](guides-tutorial-events.md) · [Reports](guides-tutorial-reports.md) · [Collecting data](guides-tutorial-collecting-data.md) · [Camera app](guides-tutorial-camera-app.md)
+
+## What it is & why it matters
+
+Fanmass is seyu's image-intelligence service. It analyses the photos from an event and
+returns normalized analytics — how many **people** it counted, projected **reach**, which
+**brands** and **clubs** appeared, **merchandise**, and demographic projections. messmass
+does not analyse images itself; it hands Fanmass the context for an event and then ingests
+the numbers Fanmass sends back so they appear in your reports alongside your own metrics.
+
+The integration has **two layers**, both sitting behind **one shared machine-auth token**:
+
+- **(A) Analytics** — messmass exposes an event's context to Fanmass, Fanmass runs its
+  analysis, and the results flow back into the event's stats under a dedicated `fanmass`
+  namespace. **Your Clicker and manual numbers are never overwritten.**
+- **(B) Mapping API** — Fanmass can also act *as if it were an operator*: create partners
+  and events, define variables, and push stat values into messmass through the same kinds
+  of writes the admin UI uses. This lets Fanmass seed data it discovered, not just report
+  on data you entered.
+
+The key principle: **messmass stays the source of truth** for organisations, partners,
+events, report templates, and report consumption. Fanmass stays the source of truth for
+image intake and analysis. They talk over versioned APIs, never by reaching into each
+other's database.
+
+## Before you start
+
+Fanmass integration needs environment variables configured by an administrator (ops
+setup). There are **two directions**, and they use **different credentials**:
+
+| Direction | Environment variable | Purpose |
+| --- | --- | --- |
+| Fanmass → messmass (inbound) | `FANMASS_INTEGRATION_TOKEN` | The shared token that authenticates Fanmass's calls into messmass. (`MESSMASS_FANMASS_TOKEN` is accepted as a fallback name.) |
+| messmass → Fanmass (outbound) | `FANMASS_BASE_URL` | Base URL of the Fanmass service messmass calls to pull analytics. |
+| messmass → Fanmass (outbound) | `FANMASS_API_KEY` | Sent as `x-api-key` on messmass's outbound calls to Fanmass. |
+
+Behaviour depending on configuration:
+
+- If `FANMASS_INTEGRATION_TOKEN` is **not set**, every inbound integration endpoint returns
+  `503 FANMASS_INTEGRATION_NOT_CONFIGURED`.
+- If a caller presents the **wrong** token, endpoints return `401 INVALID_INTEGRATION_TOKEN`.
+- If `FANMASS_BASE_URL` is **not set**, a sync (messmass pulling from Fanmass) fails with
+  `503 FANMASS_NOT_CONFIGURED`.
+
+> Note: Never paste token or key values into documents or tickets — only the variable
+> names belong in written material.
+
+**How Fanmass authenticates every inbound call:** it sends the shared token either as
+`Authorization: Bearer <token>` **or** as `x-api-key: <token>`. Both are accepted and are
+equivalent.
+
+All inbound responses share a common envelope: success is
+`{ "success": true, "data": ... }` and failure is
+`{ "success": false, "error": { "code", "message", ... } }`.
+
+## Step by step
+
+### Layer A — Analytics
+
+The analytics loop links one messmass event to one Fanmass **batch** (a batch is Fanmass's
+unit of "the images for this event") and then syncs the results.
+
+**1. Fanmass reads the event context.**
+
+```
+GET /api/integrations/fanmass/events/{eventId}/context
+```
+
+Returns everything Fanmass needs to analyse correctly: the event name and date, the
+organisation, the partner IDs and names, the event's hashtags and categorized hashtags, and
+the report template / style IDs. The payload is versioned with the contract
+`messmass.fanmass.event-context.v1`.
+
+**2. Link the event to a Fanmass batch.**
+
+```
+POST /api/integrations/fanmass/events/{eventId}/link
+```
+
+Records the `fanmassBatchId` for the event in the `fanmass_event_links` registry, with a
+status. Link status moves through a defined set as work progresses: `linked`, `importing`,
+`analyzing`, `ready`, `partial`, `failed`, `stale`, `unauthorized`, `unavailable`. You can
+read the current link back with `GET` on the same path.
+
+**3. Analytics come back — via callback or sync.**
+
+- **Callback (Fanmass pushes):**
+
+  ```
+  POST /api/integrations/fanmass/callbacks
+  ```
+
+  Fanmass posts `{ messmassEventId, batchId, status }`. When the status is `ready` or
+  `partial`, messmass immediately pulls the full analytics summary and writes it in.
+
+- **Sync (messmass pulls):**
+
+  ```
+  POST /api/integrations/fanmass/events/{eventId}/sync
+  ```
+
+  messmass calls Fanmass for the batch's analytics summary, validates it against the
+  contract `fanmass.messmass.analytics-summary.v1`, and writes the results. Add
+  `?dryRun=true` to compute and preview the mapping **without** writing, or `?force=true`
+  to sync regardless of cached state. `GET` on the same path returns the link plus the last
+  sync snapshot.
+
+**Where the numbers land.** A successful sync writes:
+
+- `projects.stats.fanmass` — the canonical Fanmass block: `peopleCount`, `projectedReach`,
+  `imageCount`, `analyzedImageCount`, `confidence`, `brands`, `clubs`, `merchandise`,
+  `gender`, `age`, `warnings`, and sync metadata.
+- **Flat mirrors** under `projects.stats.*` for report-friendly, single-value access:
+  `fanmassPeopleCount`, `fanmassProjectedReach`, `fanmassImageCount`,
+  `fanmassAnalyzedImageCount`, `fanmassConfidence`, `fanmassBrandCount`,
+  `fanmassTopBrandName`, `fanmassTopBrandCount`, `fanmassClubCount`, `fanmassTopClubName`,
+  `fanmassTopClubCount`, `fanmassWarningCount`, `fanmassSourceRunCount`,
+  `fanmassStatus`, `fanmassBatchId`, and `fanmassLastSyncedAt`.
+
+Crucially, the write only touches the `fanmass` namespace and these `fanmass*` keys — it
+does **not** overwrite your Clicker or manual stats.
+
+**4. Operators: use the "Fanmass Sync" button.**
+
+You don't need a terminal for day-to-day work. The **Events admin** action rail has a
+**Fanmass Sync** control on each event. It opens a panel where you can enter the Fanmass
+batch ID and run three actions — **link**, **dry-run**, and **sync** — backed by an
+admin-only route (`GET|POST /api/admin/fanmass/events/{eventId}`) that requires an
+authenticated admin (or superadmin) session. The panel reports the resulting status back to
+you (for example, "Fanmass analytics synced. Status: ready.").
+
+### Layer B — Mapping API
+
+These endpoints let Fanmass create and populate messmass records the same way the admin UI
+does. Records created this way are tagged with `source: "fanmass"` but are otherwise
+identical to hand-created ones (same slug generation, same derived-metric handling).
+
+**Partners.**
+
+```
+GET  /api/integrations/fanmass/partners?search=&limit=&offset=
+POST /api/integrations/fanmass/partners        { name, emoji?, logoUrl?, hashtags? }
+GET  /api/integrations/fanmass/partners/{partnerId}/events
+```
+
+List or create partners, and list a partner's events. A created partner gets an emoji
+(defaulting to a camera emoji if none is supplied, since messmass requires one) and a
+generated view slug.
+
+**Events.**
+
+```
+POST /api/integrations/fanmass/events   { eventName, eventDate?, partner1Id?, stats? }
+```
+
+Creates a messmass event (a "project") optionally attached to a partner. Any `stats`
+provided are prepared the same way the app prepares them, and the event gets view/edit
+slugs automatically.
+
+**Variables.**
+
+```
+GET  /api/integrations/fanmass/variables
+POST /api/integrations/fanmass/variables   { name, label?, type?, category?, unit?, description? }
+```
+
+List or upsert variable definitions. In messmass a **variable's `name` is the stats key**,
+so names must be camelCase (start with a letter, letters and digits only); a leading
+`stats.` prefix is stripped. Creating a new variable returns `201`; updating an existing one
+returns `200` and only touches the fields you supplied.
+
+**Push stat values.**
+
+```
+POST /api/integrations/fanmass/events/{eventId}/stats   { stats: { <variableName>: value, ... } }
+```
+
+Partial-merges values into the event's stats. It accepts either `{ stats: { ... } }` or a
+bare `{ ... }` map. **Derived (formula) variables are skipped** — you cannot push a value
+onto a variable whose value is computed from a formula; those are recalculated for you after
+the merge. The response lists which keys were `applied`.
+
+## Managing it
+
+- **Operators** live in the Events admin **Fanmass Sync** panel: link a batch, dry-run to
+  preview, then sync. Statuses like `ready` and `partial` tell you whether Fanmass finished
+  or is still working.
+- **Implementers** integrating Fanmass hit the token-authed endpoints above. Use the
+  `context` endpoint to read, `link` to associate a batch, `callbacks`/`sync` for analytics
+  (Layer A), and the `partners`/`events`/`variables`/`stats` endpoints to write (Layer B).
+- **Retries and errors** are tracked per event. The `fanmass_event_links` registry keeps
+  retry counts, the last error code/message, sync snapshots, and an audit trail — so a
+  failed sync doesn't just disappear. A `GET` on the `sync` or `link` endpoint surfaces the
+  current state.
+- **Dry-run first.** Before a real sync into a live event, run `?dryRun=true` (or the
+  dry-run button) to see the mapped values without writing them.
+
+## Gotchas & good practice
+
+- **Your metrics are safe.** Analytics sync writes only the `fanmass` namespace and
+  `fanmass*` flat mirrors. Clicker and manual numbers are never overwritten. See
+  [Collecting data](guides-tutorial-collecting-data.md).
+- **Contract versions are enforced.** A sync rejects an analytics summary whose
+  `contractVersion` is not `fanmass.messmass.analytics-summary.v1` (`409`). Keep both sides
+  on matching contract versions.
+- **Two credentials, two directions.** `FANMASS_INTEGRATION_TOKEN` guards Fanmass's calls
+  *into* messmass; `FANMASS_API_KEY` + `FANMASS_BASE_URL` are what messmass uses to call
+  *out to* Fanmass. A "not configured" error tells you which side is missing.
+- **Camel-case variable names only.** The mapping API rejects names that aren't camelCase
+  (`400 INVALID_VARIABLE_NAME`). Remember the name *is* the stats key.
+- **You can't push derived variables.** Formula-computed variables are ignored on a stats
+  push and recomputed automatically — don't expect a pushed value to "stick" on one.
+- **A partner is optional on a mapped event, but useful.** A Fanmass-created event without a
+  partner still exists, but partner-scoped views and Camera-app provisioning both key off
+  the partner. See [Partners](guides-tutorial-partners.md) and
+  [Camera app](guides-tutorial-camera-app.md).
+- **Timeouts.** Outbound calls to Fanmass are time-bounded, so a slow Fanmass surfaces as a
+  failed sync you can retry, not a hung request.
+
+## How it connects
+
+- **[Events](guides-tutorial-events.md)** — every Fanmass link, sync, and stat push targets
+  one event; the "Fanmass Sync" control lives on the Events admin.
+- **[Reports](guides-tutorial-reports.md)** and
+  **[Report variants](guides-tutorial-report-variants.md)** — Fanmass metrics become report
+  variables. Report formulas can reference the nested tokens like `[fanmass.peopleCount]`
+  and `[fanmass.brands]`, or the flat mirrors such as `[fanmassPeopleCount]`.
+- **[Collecting data](guides-tutorial-collecting-data.md)** — Fanmass analytics sit
+  *beside* your Clicker/manual data in the same event stats, not on top of it.
+- **[Camera app](guides-tutorial-camera-app.md)** — the sibling integration. The Camera app
+  captures the photos; Fanmass analyses them. Both share `FANMASS_INTEGRATION_TOKEN` for
+  their operator/ingest endpoints.
+
+## Screenshots
+_Screenshots to be added._
+
+## Related tutorials
+
+- [Getting started](guides-tutorial-getting-started.md)
+- [Events](guides-tutorial-events.md)
+- [Partners](guides-tutorial-partners.md)
+- [Reports](guides-tutorial-reports.md)
+- [Report variants](guides-tutorial-report-variants.md)
+- [Collecting data](guides-tutorial-collecting-data.md)
+- [Camera app integration](guides-tutorial-camera-app.md)

--- a/docs/guides/guides-tutorial-getting-started.md
+++ b/docs/guides/guides-tutorial-getting-started.md
@@ -1,0 +1,137 @@
+# Getting Started with messmass
+Status: Active
+Last Updated: 2026-07-20T00:00:00.000Z
+Canonical: Yes
+Owner: Documentation
+
+> Audience: New operators & implementation partners · Prerequisites: A messmass account (or an admin who can create one) · Related: [Tutorials index](guides-tutorials-index.md) · [Organisations](guides-tutorial-organisations.md) · [Partners](guides-tutorial-partners.md)
+
+## What it is & why it matters
+
+messmass is an event-intelligence and partner-reporting platform for sports organizations, venues, and brands. It captures what happens around a live event — fan photos, engagement, reach, sponsor exposure — and turns that raw capture into styled, shareable reports for partners and sponsors.
+
+The whole product hangs off one mental model. Learn it once and every screen makes sense:
+
+**Organisation → Partner → Event → Report**
+
+- **Organisation** — the top-level tenant that groups partners (for example a league or a holding brand). Superadmin-only. See [Organisations](guides-tutorial-organisations.md).
+- **Partner** — a club, federation, venue, or sponsor that owns events and carries reusable defaults (emoji, hashtags, logo, report template, clicker set). See [Partners](guides-tutorial-partners.md).
+- **Event** — a single match, activation, or session where data is actually captured. See [Events](guides-tutorial-events.md).
+- **Report** — the styled, shareable output rolled up from event data, published per event, per partner, or per organisation.
+
+Data flows left to right: you set up an organisation and its partners, run events under those partners, capture data during each event, and the report surfaces update from that data.
+
+### How data gets captured
+
+messmass supports three capture paths that all land in the same event record:
+
+- **Clicker / Manual editor** — the live event editor at `/edit/[event-slug]`. **Clicker Mode** gives fast button-based tallying during a live event; **Manual Mode** gives exact field-by-field entry for correction and completion. Connected collaborators see updates in realtime. See [Collecting data](guides-tutorial-collecting-data.md).
+- **Google Sheets** — a partner can connect a Google Sheet so event rows sync in both directions (Sheet to messmass and messmass to Sheet). See [Google Sheets](guides-tutorial-google-sheets.md).
+- **Fanmass** — the external capture app writes data into messmass through the write API (a user needs API write access enabled). See [Fanmass](guides-tutorial-fanmass.md).
+
+Once data is in the event, the report routes render it: `/report/[event-slug]`, `/partner-report/[partner-slug]`, and `/organization-report/[id]`.
+
+## Before you start
+
+- **You need an account.** If you do not have one, an admin creates it, or you self-register (see below) and ask a superadmin to raise your role.
+- **Know your role.** Access is role-gated, so what you can see depends on the role you were granted (details below).
+- **Have your login URL.** The admin workspace lives under `/admin`; sign in at `/admin/login`.
+
+### User roles
+
+messmass uses five roles in a strict hierarchy (`guest < user | api < admin < superadmin`):
+
+| Role | What it is for | Representative access |
+|------|----------------|-----------------------|
+| **guest** | New sign-ups awaiting elevation | Help page only |
+| **user** | Day-to-day entity work | Events, Partners, Filters |
+| **api** | Programmatic access via API key | API-key requests (same level as user) |
+| **admin** | Content and reporting management | Everything a user has, plus Reporting Workspace, Analytics Workspace, KYC Variables, Clicker Sets, Bitly Links, Quick Add, Messages |
+| **superadmin** | Full system control | Everything, plus Organizations, Users, Hashtags, Categories, Cache, Insights |
+
+> Note: In single-sign-on (SSO) deployments the `admin` role is treated as the highest privilege (equivalent to `superadmin`) for menu visibility. On a password-only deployment, `admin` and `superadmin` are distinct as shown above.
+
+Guests are intentionally boxed into the Help surface so they can learn the product map before higher-permission work is enabled. To move up, a guest contacts a superadmin with their email and requests `user`, `admin`, or `superadmin`.
+
+## Step by step
+
+### 1. Log in at `/admin/login`
+
+1. Open `/admin/login`.
+2. Enter your **Email** (the placeholder shows the accepted forms, e.g. `admin` or `admin@messmass.com`) and **Password**.
+3. Click **Sign in to Admin**.
+4. If your deployment has SSO enabled, you will also see **Sign in with DoneIsBetter** — use that instead when your organisation requires it. See [Authentication & SSO](guides-tutorial-authentication-sso.md).
+
+Don't have an account yet? Click **Create Account** on the login card (this takes you to `/admin/register`). New self-registrations start as **guest** until a superadmin raises the role.
+
+### 2. Land in the admin workspace (`/admin`)
+
+`/admin` is the single command center. Everything is grouped by job, not by legacy route name:
+
+- **Operations** — Events, Partner Activation, Quick Add, Messages
+- **Entities** — Partners, Organizations, Project Partners
+- **Reports** — Reporting Workspace, Report Builder, Report Themes, Content Library, Chart Algorithms
+- **Data** — KYC Variables, Clicker Sets, Bitly Links, Filters, Hashtags, Categories
+- **Analytics** — Analytics Home, Sponsorship Hub, Executive / Marketing / Operations dashboards, Insights
+- **System** — Users, Main Page, Cache, Help
+
+You only see the groups and tiles your role allows.
+
+### 3. Open in-product help (`/admin/help`)
+
+`/admin/help` is available to every role, including guests. It carries the live workspace map, core workflows, sharing/export notes, and troubleshooting. Use it as the always-current companion to these tutorials.
+
+### 4. Follow the entity flow
+
+Set up entities in the order the mental model implies:
+
+1. (Superadmin) Create the **Organisation** — [Organisations](guides-tutorial-organisations.md).
+2. Create the **Partner(s)** under it — [Partners](guides-tutorial-partners.md).
+3. Create **Events** for a partner — [Events](guides-tutorial-events.md).
+4. Capture data in the editor, then **Open Report** — [Collecting data](guides-tutorial-collecting-data.md) and [Reports](guides-tutorial-reports.md).
+
+## Managing it
+
+- **Editing your own profile / password:** ask a superadmin; user and role administration lives under **Users** (`/admin/users`), which is superadmin-only.
+- **Requesting more access:** guests and users ask a superadmin to elevate their role. There is no self-service role change.
+- **Finding a feature you can't see:** start from `/admin` and use the workspace grouping rather than an old bookmark. If a page is missing, your role may not include it, or a legacy route now redirects into the canonical workspace.
+- **Where output lives:** every shareable output is a report route — event (`/report/[event-slug]`), partner (`/partner-report/[partner-slug]`), organisation (`/organization-report/[id]`). Open first, then share a recipient-safe link. See [Sharing & access](guides-tutorial-sharing-access.md).
+
+### Getting data back out
+
+Reports are not just for viewing — they export three ways:
+
+- **CSV** — data extraction for spreadsheet analysis.
+- **PNG** — an individual chart image exported from a report surface.
+- **Report output** — the full styled, shareable stakeholder view delivered through the report routes above.
+
+The workflow is "open first, share second": open the report or editor to confirm the data, then generate a recipient-safe share link when you are ready to distribute.
+
+## Gotchas & good practice
+
+- **Role gates are real.** If a colleague "can't find" Organizations or Users, it is almost always because they are not a superadmin — not a bug.
+- **Guests see only Help.** That is by design; it is the safe landing spot before elevation.
+- **Clicker first, Manual second.** During a live event, tally fast in Clicker Mode, then switch to Manual Mode to correct and complete.
+- **One capture path, one record.** Clicker/Manual, Google Sheets, and Fanmass all write to the same event — pick the path that fits the moment; they are not separate datasets.
+- **Set up defaults on the Partner, not the event.** Report template, clicker set, style, hashtags, and logo defined on a partner flow down to its events, saving repeated setup.
+
+## How it connects
+
+- **Auth** underpins everything you do here — see [Authentication & SSO](guides-tutorial-authentication-sso.md) and the reference [features: Authentication](../features/features-authentication.md).
+- **Organisations** own **Partners**, which own **Events**, which produce **Reports** — the four tutorials that anchor this path.
+- The in-product **Help** (`/admin/help`) mirrors the current admin information architecture and is the fastest way to confirm a route.
+- For a system-level survey of capabilities, see the reference [features: Overview](../features/features-overview.md).
+
+## Screenshots
+_Screenshots to be added._
+
+## Related tutorials
+
+- [Tutorials index](guides-tutorials-index.md)
+- [Organisations](guides-tutorial-organisations.md)
+- [Partners](guides-tutorial-partners.md)
+- [Events](guides-tutorial-events.md)
+- [Collecting data](guides-tutorial-collecting-data.md)
+- [Reports](guides-tutorial-reports.md)
+- [Sharing & access](guides-tutorial-sharing-access.md)
+- [Authentication & SSO](guides-tutorial-authentication-sso.md)

--- a/docs/guides/guides-tutorial-google-sheets.md
+++ b/docs/guides/guides-tutorial-google-sheets.md
@@ -1,0 +1,180 @@
+# Tutorial: Google Sheets sync
+Status: Active
+Last Updated: 2026-07-20T00:00:00.000Z
+Canonical: Yes
+Owner: Documentation
+
+> Audience: Operators and technical implementers · Prerequisites: Admin sign-in, a Google service account, a partner to connect · Related: [Partners](guides-tutorial-partners.md), [Events](guides-tutorial-events.md), [Bitly integration](guides-tutorial-bitly.md)
+
+## What it is & why it matters
+
+Google Sheets sync gives spreadsheet-oriented partners a familiar way to manage their events. A partner's events are kept in step **bidirectionally** between a Google Sheet and messmass: they can bulk-edit rows in the sheet, and you can push the latest messmass numbers back into it. The connection is **per partner** — one sheet holds one partner's events, one row per event.
+
+Why it matters: not every partner wants to work inside the admin console. A club's marketing team may live in spreadsheets. This integration lets them add and edit events in a sheet they already understand, while messmass stays the source of truth for computed statistics.
+
+The mechanism is simple and robust:
+
+- Row matching is anchored on **column A**, which holds the messmass event **UUID**. messmass fills it in the first time a row syncs, and uses it forever after to find the same event again.
+- A fixed **42-column layout (A–AP)** maps each cell to a messmass field. A few columns are computed and read-only (event name, All Images, Total Fans, sync status).
+- Authentication is via a Google **service account**, not a personal Google login, so sync runs unattended.
+
+## Before you start
+
+1. **Sign in as an admin.** All `/api/partners/[id]/google-sheet/*` routes are admin-only.
+2. **Create a Google service account and enable the Google Sheets API.** Follow the step-by-step in [../setup/setup-google-service-account-setup.md](../setup/setup-google-service-account-setup.md). You end up with a service-account email and a private key.
+3. **Provide the credentials** in one of two ways (never paste the private key into the app or into docs):
+   - Environment variables `GOOGLE_SHEETS_SERVICE_ACCOUNT_EMAIL` and `GOOGLE_SHEETS_PRIVATE_KEY` (the private key may be raw with preserved `\n` newlines, or base64-encoded), **or**
+   - A `.google-service-account.json` key file at the project root. If that file exists it is used first; otherwise the integration falls back to the environment variables.
+4. **Share the target sheet with the service-account email as Editor.** Viewer access is not enough — sync writes back UUIDs and pushed data. Uncheck "Notify people" when sharing.
+5. **Have the partner created** whose events you want to sync. See [Partners](guides-tutorial-partners.md).
+
+Rotate the service-account key periodically and only share the specific sheets that need syncing — a service account you have over-shared can read every sheet it was added to.
+
+> Note: If credentials are missing, the client raises a clear "Missing Google Sheets credentials" error telling you to either create `.google-service-account.json` or set the two environment variables.
+
+### How authentication works
+
+The integration signs in as the service account, not as a person. On each call it builds a Google JWT client scoped to the Sheets API (and the Drive API when it needs to create or rename a spreadsheet). It prefers the `.google-service-account.json` key file if present, and otherwise reads the email and private key from the environment. This is why the sheet must be **shared with the service-account email**: the service account is the "user" doing the reading and writing, and it can only touch sheets that have been shared with it. No end-user OAuth pop-up is involved, which is what lets the nightly job run unattended.
+
+## Step by step
+
+Everything below is driven from the **partner detail page**.
+
+### 1. Connect a sheet
+
+You have two ways to connect:
+
+- **Auto-provision (recommended for new partners).** Use "Create & Connect New Google Sheet". messmass creates a fresh spreadsheet, writes the header row, populates any events the partner already has, prefixes the partner's UUID into the sheet title so it is traceable, and connects it. The service account already has access, so you just open the returned URL and share it with the partner's editors.
+- **Connect an existing sheet.** Open the Google Sheets settings, paste the **Sheet ID** (from the sheet's URL), set the tab name (default "Events") and a sync mode (manual or auto), share the sheet with the service-account email as Editor, and connect. Behind the scenes this is `POST /api/partners/[id]/google-sheet/connect`.
+
+After connecting, a status card shows the connection and the last sync time.
+
+> Note: The default tab name is "Events". If your sheet uses a different tab, set that name when you connect so reads and writes target the right tab.
+
+### 2. Add events in the sheet
+
+Fill a row and leave **column A empty** — messmass generates the UUID on first pull. The event type is detected from which columns you fill:
+
+- **Two-partner event:** Partner 1 (col B) + Partner 2 (col C) → name becomes "Partner 1 vs Partner 2".
+- **Single-partner event:** Partner 1 (col B) + Event Title (col D) → name is the title.
+- **Standalone event:** Event Title (col D) only.
+
+A row with neither a partner nor a title is invalid.
+
+### 3. Pull (Sheet → messmass)
+
+Pull reads sheet rows and creates or updates the matching messmass events:
+
+- **Manually:** click "Pull All Events" on the partner page (`POST /api/partners/[id]/google-sheet/pull`). New events are created, existing ones (matched by UUID) are updated, and the UUID is written back to column A for any new rows.
+- **Event-level:** on an event's editor page (`/edit/[slug]`), when the event is sheet-backed, a "Pull from Sheet" button pulls just that one row.
+- **Automatically:** a daily job at **3:00 AM UTC** pulls for every partner whose connection is enabled and set to `auto`.
+
+### 4. Push (messmass → Sheet)
+
+Push writes messmass event data back into the sheet:
+
+- **Manually only** — there is no automatic push. Click "Push All Events" on the partner page (`POST /api/partners/[id]/google-sheet/push`), or "Push to Sheet" on an event editor for a single row.
+- Computed **formula cells are preserved**: the data columns are updated while the All Images (`=J+K+L`) and Total Fans (`=N+O`) formulas are left in place.
+
+### 5. Check status or disconnect
+
+- **Status:** `GET /api/partners/[id]/google-sheet/status` returns the connection state; add `?checkHealth=true` for a health check (row count and accessibility).
+- **Disconnect:** `DELETE /api/partners/[id]/google-sheet/disconnect` removes the connection and cleans up the sync configuration. The sheet itself is untouched.
+
+### Supporting endpoints
+
+Beyond connect/pull/push/status/disconnect, the partner's Google Sheet routes include a few helpers you will not usually call by hand but which power the UI:
+
+- **provision** — create a brand-new sheet, set it up, and connect it in one step (the "Create & Connect New Google Sheet" button).
+- **setup** — configure a blank sheet you created yourself (write headers and formatting) so a pasted URL becomes sync-ready.
+- **rename** — prefix the spreadsheet title with the partner UUID so the sheet is traceable back to its partner.
+
+### Worked example: add three events in the sheet
+
+Add three rows, each leaving column A empty:
+
+| Row | Col B (Partner 1) | Col C (Partner 2) | Col D (Event Title) | Col F (Date) | Resulting event |
+|-----|-------------------|-------------------|---------------------|--------------|-----------------|
+| 2 | FC Barcelona | Real Madrid | *(empty)* | 2026-01-15 | "FC Barcelona vs Real Madrid" (two-partner) |
+| 3 | FC Barcelona | *(empty)* | Fan Fest 2026 | 2026-02-10 | "Fan Fest 2026" (single-partner) |
+| 4 | *(empty)* | *(empty)* | Summer Festival | 2026-06-20 | "Summer Festival" (standalone) |
+
+Then click **Pull All Events** on the partner page. messmass creates three events, writes a UUID into column A of each row, and reports something like "Pulled 3 events (3 created, 0 updated)". Edit and pull again later and those rows update in place instead of duplicating, because the UUID now matches.
+
+## Managing it
+
+- **The 42-column contract (A–AP).** Column A is the UUID. Columns B–F are identity (partners, title, auto name, date). Columns G onward are statistics — attendance, images, fan counts, demographics, merchandise, visit sources — ending with Bitly totals, a last-modified timestamp, sync status and free-text notes. Read-only/computed columns are: A (UUID), E (event name), M (All Images), P (Total Fans) and AO (sync status). Leave those to messmass.
+
+### Column map by group
+
+| Columns | Group | Examples |
+|---------|-------|----------|
+| A | Identity key | messmass UUID (read-only) |
+| B–F | Event identity | Partner 1, Partner 2, Event Title, Event Name (read-only), Event Date |
+| G–I | Result | Attendees, Result Home, Result Visitor |
+| J–M | Images | Remote, Hostess, Selfies, All Images (computed, read-only) |
+| N–P | Fans | Remote Fans, Stadium, Total Fans (computed, read-only) |
+| Q–V | Demographics | Female, Male, Gen Alpha, Gen YZ, Gen X, Boomer |
+| W–AB | Merchandise | Merched, Jersey, Scarf, Flags, Baseball Cap, Other |
+| AC–AK | Visit sources | QR, Short URL, Web, Facebook, Instagram, YouTube, TikTok, X, Trustpilot |
+| AL–AM | Bitly | Total Bitly Clicks, Unique Bitly Clicks |
+| AN–AP | Sync metadata | Last Modified, Sync Status (read-only), Notes |
+- **Bitly totals show up here.** Columns for **Total Bitly Clicks** and **Unique Bitly Clicks** carry the same numbers you manage in the [Bitly integration](guides-tutorial-bitly.md), so partners see click evidence alongside their events.
+- **Conflict handling.** Both directions compare timestamps (the sheet's "Last Modified" column against messmass's stored modified time). If the destination is newer than the source, a confirmation modal warns you before overwriting; otherwise the sync proceeds.
+- **Scheduled sync is pull-only.** The nightly job never pushes. If you want messmass numbers reflected in the sheet, push manually.
+
+### The nightly sync in detail
+
+A daily cron runs at 3:00 AM UTC against `POST /api/cron/google-sheets-sync`, authorised by an `Authorization: Bearer <CRON_SECRET>` header (the schedule is defined as `0 3 * * *`). It processes every partner whose Google Sheet connection is enabled and whose sync mode is `auto`, pulling each partner's sheet into messmass. Sync results and errors are logged so failures can be reviewed, and superadmins are notified when a scheduled sync fails. Partners set to manual mode are skipped by the job and only sync when someone clicks a button.
+
+### Manual vs auto sync mode
+
+When you connect a sheet you choose a sync mode, and it changes only how **pull** is triggered:
+
+| Mode | Pull (Sheet → messmass) | Push (messmass → Sheet) |
+|------|-------------------------|-------------------------|
+| Manual | Only when you click Pull | Only when you click Push |
+| Auto | Nightly at 3 AM UTC, plus manual | Only when you click Push (never automatic) |
+
+Choose **auto** for partners who edit their sheet regularly and expect messmass to keep up on its own. Choose **manual** for sheets you touch rarely, or while you are still validating the mapping.
+
+## Gotchas & good practice
+
+- **Never edit column A.** The UUID is how messmass finds the row again. Change it and the row will be treated as a new event (or fail to match), producing duplicates.
+- **Do not overwrite computed columns.** Event name, All Images, Total Fans and Sync Status are maintained by messmass. If a formula gets clobbered, restore it (`=J2+K2+L2` for All Images, `=N2+O2` for Total Fans) or push events to rewrite it.
+- **Share as Editor, not Viewer.** "The caller does not have permission" almost always means the sheet was shared with the wrong access level or the wrong email.
+- **Preserve the private key format.** Keep the `\n` newlines (or base64-encode the whole key). "Invalid JWT signature" is the classic symptom of a mangled key.
+- **One sheet per partner.** The current model is one sheet, one partner, many event rows. Do not point two partners at the same sheet.
+- **Duplicate UUIDs break pulls.** If you copy rows in the sheet, clear column A on the copies so each event gets its own UUID.
+- **Secrets stay in the environment (or the key file), never in the app UI.** The two environment variable names are `GOOGLE_SHEETS_SERVICE_ACCOUNT_EMAIL` and `GOOGLE_SHEETS_PRIVATE_KEY`. If you use the `.google-service-account.json` file instead, keep it out of version control.
+
+### Quick troubleshooting
+
+| Symptom | Likely cause | What to do |
+|---------|--------------|------------|
+| "Missing Google Sheets credentials" | Neither the key file nor both env vars are set | Add `.google-service-account.json`, or set `GOOGLE_SHEETS_SERVICE_ACCOUNT_EMAIL` and `GOOGLE_SHEETS_PRIVATE_KEY` |
+| "The caller does not have permission" | Sheet not shared, or shared as Viewer | Share the sheet with the service-account email as **Editor** |
+| "Invalid JWT signature" | Private key newlines lost | Preserve the `\n` characters (or base64-encode the key) and keep the quotes |
+| Duplicate events after a pull | Column A duplicated by copied rows | Clear column A on the copies and pull again |
+| An event will not match its row | Column A UUID was edited or deleted | Restore the UUID, or pull to regenerate it for a truly new row |
+| All Images / Total Fans blank | Formula overwritten | Restore `=J2+K2+L2` (M) and `=N2+O2` (P), or push to rewrite |
+
+## How it connects
+
+- **Partners** own the connection; the sheet syncs that one partner's events. See [Partners](guides-tutorial-partners.md).
+- **Events** are the rows; event type detection turns partner/title columns into named events, and the editor exposes per-event pull/push. See [Events](guides-tutorial-events.md).
+- **Bitly** click totals ride along in the sheet's dedicated columns. See [Bitly integration](guides-tutorial-bitly.md).
+- The nightly sync is secured with the same scheduled-job pattern (`CRON_SECRET`) described in [Authentication, roles & SSO](guides-tutorial-authentication-sso.md).
+
+For the full column map, conflict rules and API reference, see the feature guide at [../features/features-google-sheets-integration.md](../features/features-google-sheets-integration.md), and the credential walkthrough at [../setup/setup-google-service-account-setup.md](../setup/setup-google-service-account-setup.md).
+
+## Screenshots
+_Screenshots to be added._
+
+## Related tutorials
+
+- [Partners](guides-tutorial-partners.md)
+- [Events](guides-tutorial-events.md)
+- [Bitly integration](guides-tutorial-bitly.md)
+- [Sport databases](guides-tutorial-sport-databases.md)
+- [Authentication, roles & SSO](guides-tutorial-authentication-sso.md)

--- a/docs/guides/guides-tutorial-hashtags-filters.md
+++ b/docs/guides/guides-tutorial-hashtags-filters.md
@@ -1,0 +1,101 @@
+# Tutorial: Hashtags, categories & filters
+Status: Active
+Last Updated: 2026-07-20T00:00:00.000Z
+Canonical: Yes
+Owner: Documentation
+
+> Audience: Internal operators & admins · Prerequisites: Admin sign-in; events/partners already tagged with hashtags · Related: [Partners](guides-tutorial-partners.md) · [Events](guides-tutorial-events.md) · [Sharing & access](guides-tutorial-sharing-access.md)
+
+## What it is & why it matters
+Hashtags are how you tag and later re-slice your data. You attach hashtags to partners and events; then you can pull up **every** event carrying a tag and see its aggregated stats, or combine several tags into a single filtered report.
+
+Three admin surfaces work together:
+
+| Surface | Route | Purpose |
+|---|---|---|
+| **🏷️ Hashtag Manager** | `/admin/hashtags` | Manage hashtag colours and browse all project hashtags |
+| **🌍 Category Manager** | `/admin/categories` | Define hashtag categories (name, colour, display order) |
+| **🔍 Hashtag Filter** | `/admin/filter` | Combine multiple hashtags into an aggregated, shareable report |
+
+Why categories matter: a **categorized** hashtag belongs to a named group (e.g. category `city` → `budapest`, `vienna`, `prague`) and inherits that category's colour; a **general** (uncategorized) hashtag stands alone with only its own colour. Categories keep large tag sets organised and colour-coded consistently, so `budapest` and `vienna` always read as "cities" at a glance.
+
+Two report destinations flow out of this:
+- **Single-hashtag report** at `/hashtag/{hashtag}` — everything carrying one tag.
+- **Multi-hashtag filter report** at `/filter/{slug}` — everything carrying *all* of several tags, with a shareable, password-protectable slug.
+
+## Before you start
+- Sign in as an admin. The Hashtag Manager and these surfaces are **admin-only** — non-admins see "Access Denied".
+- Have events or partners already tagged. You attach hashtags on the event and partner forms (see [Events](guides-tutorial-events.md) and [Partners](guides-tutorial-partners.md)); this tutorial covers organising and reporting on those tags, not the initial tagging UI.
+- Know that the resulting **filter and single-hashtag report pages are password-gated** — see [Sharing & access](guides-tutorial-sharing-access.md).
+
+## Step by step
+
+### 1. Manage hashtag colours (`/admin/hashtags`)
+Open **🏷️ Hashtag Manager** ("Manage hashtag colors and browse all project hashtags"). Use the hero **search** to find project hashtags. From here you review every hashtag in use and adjust its colour so it renders consistently across reports and bubbles.
+
+### 2. Create and order categories (`/admin/categories`)
+Open **🌍 Category Manager** ("Manage hashtag categories with colors and display order"). Click **New Category** and set:
+- **Category Name** — lowercase letters, numbers, underscores, or hyphens only (e.g. `sport`, `team`, `location`); up to 50 characters. Some reserved names (`default`, `all`, `none`, …) are not allowed.
+- **Display Order** — a number controlling where the category sits (lower = earlier).
+- **Category Color** — pick with the colour swatch or type a hex value (e.g. `#3b82f6`).
+
+Edit or delete a category from its row/card (delete asks for confirmation). A categorized hashtag inherits its category's colour unless an individual colour overrides it.
+
+### 3. Build a multi-hashtag filter report (`/admin/filter`)
+Open **🔍 Hashtag Filter** ("Filter projects by multiple hashtags and generate shareable URLs"):
+1. **Select tags.** Search the hashtag list and tick the hashtags you want. Use **Load 20 more** to page through. Your selection is reflected in the page URL.
+2. **Apply.** Click **🔍 Apply Filter (N tags)**. The page aggregates every project matching **all** selected tags and shows combined stats — Images, Fans, Gender, Age Groups, Merchandise, and performance metrics — plus the matched project count and date range.
+3. **Choose a style.** Pick a report style from the selector (or leave "— Use Default/Global —"); the choice is saved for this tag set (a small "✓ saved" indicator confirms it).
+4. **Share.** Click **🔗 Share Filter** to generate a shareable slug. The report is served at `/filter/{slug}` and can be **password-protected**.
+5. **Export.** **📄 Export CSV** downloads the aggregated numbers as a spreadsheet.
+
+Below the stats, a **📊 Matching Projects** list links each contributing event to its own report.
+
+### 4. Open a single-hashtag report (`/hashtag/{hashtag}`)
+For a report on just one tag, use the public route `/hashtag/{hashtag}` (e.g. `/hashtag/budapest`). Like filter reports, this page is password-gated.
+
+### 5. A worked example
+Say you tag events with a `city` category (`budapest`, `vienna`) and a general tag `vip`. To see how VIP activations performed across just Budapest:
+1. In **Category Manager**, confirm `city` exists with `budapest` and `vienna` assigned, coloured, and ordered.
+2. In **Hashtag Filter**, tick `budapest` and `vip`, then **Apply Filter (2 tags)**. Only events carrying **both** tags are aggregated.
+3. Read the combined Images / Fans / Gender / Age / Merchandise stats and the matched-project list.
+4. Pick a style, click **🔗 Share Filter** to mint a `/filter/{slug}`, protect it with a password, and hand the link to the stakeholder.
+5. If nothing matches, remove `vip` and re-apply — the AND logic may simply have no overlap.
+
+## Managing it
+**Categorized vs general hashtags.** A hashtag assigned to a category is *categorized* and takes the category's colour and grouping. A hashtag with no category is *general* (uncategorized) and carries only its own individual colour. Both are searchable and both can be combined in the filter.
+
+**Colour resolution.** The effective colour of a hashtag is its individual colour if set, otherwise its category colour, otherwise a default. Set category colours first for consistency, and only override individual hashtags when you need an exception.
+
+**Filter logic is AND.** Selecting three tags returns projects that carry **all three**, then sums their stats. Add tags to narrow; remove tags to broaden.
+
+**Styles are per-tag-set.** The style you pick on the filter page is remembered against that exact combination of tags, so re-opening the same filter restores your chosen look. Report styles themselves are covered in [Report themes](guides-tutorial-report-themes.md).
+
+**Browsing and paging.** Both the Hashtag Manager and the Filter page load hashtags in pages of 20 with a **Load 20 more** control and a "Showing X of Y" counter, and each has a debounced search box. On the Filter page the selection is mirrored into the URL as `?tags=a,b,c`, so you can bookmark or share a *draft* filter link even before generating a protected slug (the draft link still requires an admin session; only the `/filter/{slug}` share is for outside viewers).
+
+**What the CSV contains.** The filter **Export CSV** writes a header block (the filter tags joined with AND, the projects-matched count, the date range, and a generated timestamp) followed by category/metric/count rows across Images, Fans, Gender, Age, Merchandise, and Success-Manager metrics — the same numbers shown on screen, ready for a spreadsheet.
+
+## Gotchas & good practice
+- **Admin-only pages.** All three surfaces require an admin/superadmin session; there is no partner self-serve here.
+- **Category names are strict.** Lowercase alphanumerics with `_`/`-`, ≤ 50 chars, and no reserved words — the form rejects anything else.
+- **More tags = fewer results.** Because the filter is an AND, over-selecting can return zero projects. Start broad and add tags one at a time.
+- **Share links are gated.** A `/filter/{slug}` or `/hashtag/{hashtag}` page enforces a page password — always send the URL and password out-of-band (see [Sharing & access](guides-tutorial-sharing-access.md)).
+- **Colour once, at the category.** Setting colours per individual hashtag when a category would do creates drift; prefer category colours and reserve overrides for genuine exceptions.
+- **Deleting a category** removes the grouping; the hashtags themselves remain but revert to general/uncategorized behaviour.
+
+## How it connects
+- **Where tags come from:** hashtags are attached to [Events](guides-tutorial-events.md) and [Partners](guides-tutorial-partners.md).
+- **What filter reports show:** the same stats and charts as single-event [Reports](guides-tutorial-reports.md), aggregated across matches.
+- **Styling shared reports:** [Report themes](guides-tutorial-report-themes.md).
+- **Password-gating shared pages:** [Sharing reports & access control](guides-tutorial-sharing-access.md).
+- **Feature reference:** [Hashtag system](../features/features-hashtag-system.md).
+
+## Screenshots
+_Screenshots to be added._
+
+## Related tutorials
+- [Partners](guides-tutorial-partners.md)
+- [Events](guides-tutorial-events.md)
+- [Reports](guides-tutorial-reports.md)
+- [Report themes](guides-tutorial-report-themes.md)
+- [Sharing reports & access control](guides-tutorial-sharing-access.md)

--- a/docs/guides/guides-tutorial-organisations.md
+++ b/docs/guides/guides-tutorial-organisations.md
@@ -1,0 +1,136 @@
+# Tutorial: Organisations
+Status: Active
+Last Updated: 2026-07-20T00:00:00.000Z
+Canonical: Yes
+Owner: Documentation
+
+> Audience: Superadmins · Prerequisites: Superadmin role, at least one Partner to assign · Related: [Getting started](guides-tutorial-getting-started.md) · [Partners](guides-tutorial-partners.md) · [Camera app](guides-tutorial-camera-app.md)
+
+## What it is & why it matters
+
+An **organisation** is the top-level grouping in messmass. It sits above partners and provides org-scoped tenancy: a named container that groups the **Partners** who actually own events and reports.
+
+You use organisations to:
+
+- Group related partners under one parent (a league, federation, or holding brand).
+- Produce an **organisation report** that aggregates every member partner's stats and events into one aggregate view.
+- Keep reporting multi-tenant — non-superadmin users can be scoped to specific organisation IDs.
+
+Organisations do not own events directly. They group **Partners**, and the partners own the activity. Membership is the link between them.
+
+> Note: Organisation management is **superadmin-only**. The **Add Organization** button and the create/edit/delete/member APIs all require the superadmin role. If you are an admin or user, you will not see this surface.
+
+## Before you start
+
+- **Be a superadmin.** Everything on `/admin/organizations` is gated to superadmin.
+- **Have partners ready.** An organisation is only useful once partners are assigned to it. Create partners first via [Partners](guides-tutorial-partners.md).
+- **Know the one-org rule.** A partner belongs to exactly **one** organisation at a time. Assigning it here moves it out of any previous organisation.
+
+## Step by step
+
+### 1. Open the organisation workspace
+
+Go to `/admin/organizations` (Entities group in the admin workspace). The page is titled **Organization Management** with the subtitle "Create organizations, assign partner members, and open report/editor tools."
+
+### 2. Create an organisation
+
+1. Click **Add Organization** (top-right; visible to superadmins only).
+2. Enter the organisation **Name** (for example, `Champions Hockey League`).
+3. Submit. The organisation is created immediately.
+
+What happens on save:
+
+- A URL-safe **slug** is generated automatically from the name (lowercased, non-alphanumerics collapsed to `-`, de-duplicated so no two organisations collide).
+- **Status** defaults to `active`.
+- **Metadata** starts empty and is filled in later through the editor (see below).
+
+> Note: The reused administrator reference lists Name, Slug, Status, and Metadata as organisation fields. In the current create modal you supply the **Name**; slug, status, and metadata are set automatically and then managed through **Edit** and the organisation editor.
+
+### 3. Edit an organisation
+
+From the organisation list, use the row's **Edit** action to update:
+
+- **Name**
+- **Status** (`active` / `inactive`)
+
+Edits preserve existing metadata keys unless you change them explicitly.
+
+### 4. Manage members (assign partners)
+
+1. On the organisation row, click **Manage Members**.
+2. Use the predictive-search selector to find partners by name or current organisation.
+3. Add or remove partners from the selected set.
+4. Click **Save Assignments**.
+
+Behaviour to keep in mind:
+
+- Changes are **staged in the modal** and only applied when you click **Save Assignments**.
+- A partner can belong to only **one** organisation. Adding it here removes it from wherever it was.
+- Removing a partner from the selected set unassigns it from this organisation.
+
+### 5. Open the organisation report and editor
+
+Each organisation row exposes:
+
+- **Report** → opens the protected share dialog for `/organization-report/[id]`.
+- **Edit Stats** → the organisation content editor at `/organization-edit/[id]`.
+- **Edit** → inline admin editing of name and status.
+- **Manage Members** → the predictive-search membership assignment above.
+
+The organisation report aggregates organisation-level metadata stats, member-partner stats, and the related projects/events of the assigned partners.
+
+The organisation editor manages report configuration through `metadata`, with the same parity fields as partner and event reports:
+
+- **Report Visual Style** (`metadata.styleId`)
+- **Report Template** (`metadata.reportTemplateId`, with legacy mirror `metadata.reportId`)
+- **Clicker Set** (`metadata.clickerSetId`)
+- **Organization Logo URL** (`metadata.logoUrl`)
+- **Organization Emoji / visibility** (`metadata.emoji`, `metadata.showEmoji`)
+
+Template resolution on the organisation report page follows: `metadata.reportTemplateId` → `metadata.reportId` (backward compatibility) → the default partner report template.
+
+## Managing it
+
+### Worked example: standing up a league
+
+1. As a superadmin, open `/admin/organizations` and click **Add Organization**. Name it `Champions Hockey League`. The slug `champions-hockey-league` is generated for you.
+2. If the member clubs do not exist yet, create them first in [Partners](guides-tutorial-partners.md).
+3. Back on the organisation row, click **Manage Members**, search for each club, add them to the selection, and click **Save Assignments**.
+4. Open the organisation editor (**Edit Stats** → `/organization-edit/[id]`) and set the report template, style, clicker set, logo, and emoji via the `metadata` fields.
+5. Click **Report** on the organisation row to open the aggregate `/organization-report/[id]` and confirm the member stats roll up as expected.
+
+### Everyday maintenance
+
+- **Reassigning partners:** re-open **Manage Members**, adjust the selection, and save. There is no separate "move" action — membership is just the selected set.
+- **Deactivating vs deleting:** set status to `inactive` when you want to retire an organisation without removing it. Delete only when it should be gone permanently.
+- **Deleting an organisation:** use the row's delete action and confirm the prompt. An organisation **cannot be deleted while partners are still assigned** — this guard prevents accidental data loss. Reassign or remove every member first, then delete.
+- **Scoping report access:** organisation reports and editors use page-specific passwords through the protected share dialog; an authenticated admin session bypasses the prompt. See [Sharing & access](guides-tutorial-sharing-access.md).
+
+## Gotchas & good practice
+
+- **Delete is guarded, not silent.** If a delete "fails," check whether partners are still assigned — that is the guard doing its job, not an error.
+- **Membership is exclusive.** Moving a partner into a new organisation quietly removes it from the old one. Communicate the move if two teams share partners.
+- **Name drives the slug once.** The slug is generated at creation; renaming the organisation later does not necessarily regenerate the slug, so pick a clean name up front.
+- **Superadmin gate is total.** Admins cannot see this page at all — route org work through a superadmin.
+
+> Note: Creating an organisation may be mirrored into the **Camera app** as a shared identity. This mirror is created lazily — the first time one of the organisation's partners or events is provisioned into Camera, messmass ensures a matching Camera organisation and stamps the Camera organisation ID back onto the record. It is not triggered by clicking **Add Organization** on its own. See [Camera app](guides-tutorial-camera-app.md).
+
+## How it connects
+
+- **Partners** are the members of an organisation and the entities that own events — see [Partners](guides-tutorial-partners.md).
+- The organisation report reuses the same **themes**, **templates**, and **clicker sets** as partner and event reports — see [Report themes](guides-tutorial-report-themes.md) and [Reports](guides-tutorial-reports.md).
+- Camera provisioning ties organisation identity across apps — see [Camera app](guides-tutorial-camera-app.md).
+- A fuller administrator reference lives at [admin: Organization Management](admin/organizations.md).
+
+## Screenshots
+_Screenshots to be added._
+
+## Related tutorials
+
+- [Tutorials index](guides-tutorials-index.md)
+- [Getting started](guides-tutorial-getting-started.md)
+- [Partners](guides-tutorial-partners.md)
+- [Reports](guides-tutorial-reports.md)
+- [Report themes](guides-tutorial-report-themes.md)
+- [Sharing & access](guides-tutorial-sharing-access.md)
+- [Camera app](guides-tutorial-camera-app.md)

--- a/docs/guides/guides-tutorial-partners.md
+++ b/docs/guides/guides-tutorial-partners.md
@@ -1,0 +1,147 @@
+# Tutorial: Partners
+Status: Active
+Last Updated: 2026-07-20T00:00:00.000Z
+Canonical: Yes
+Owner: Documentation
+
+> Audience: Operators (user/admin) & implementation partners · Prerequisites: A messmass account with the `user` role or higher · Related: [Getting started](guides-tutorial-getting-started.md) · [Organisations](guides-tutorial-organisations.md) · [Events](guides-tutorial-events.md)
+
+## What it is & why it matters
+
+A **partner** is the team, club, federation, venue, or sponsor that owns events. In the mental model **Organisation → Partner → Event → Report**, the partner is where reusable identity and reporting defaults live.
+
+Partners matter because they are metadata templates. Set an emoji, hashtags, a logo, a report template, and a clicker set on the partner once, and every event created for that partner inherits them. That keeps a season of events consistent without re-entering setup each time.
+
+Partners also get their own shareable **partner report** (`/partner-report/[slug]`) that rolls up all of the partner's events, and can carry multiple **report variants** for different audiences or time windows.
+
+> Note: The Partners surface is available to `user`, `admin`, and `superadmin`. Reporting defaults such as report template, style, and clicker set are meaningful once you have those objects configured (see the related tutorials at the end).
+
+## Before you start
+
+- **Have a role of `user` or higher.** Guests cannot manage partners.
+- **Decide the organisation.** If this partner belongs to an organisation, you assign it from the Organizations page after creating it (see "Assigning to an organisation" below). A partner belongs to at most **one** organisation.
+- **Gather identity assets.** A name and an emoji are required. Optionally have a TheSportsDB team, a logo, hashtags, and a report template/style/clicker set in mind.
+
+## Step by step
+
+Open **Partners** at `/admin/partners` (Entities group). The page is titled **Partner Management**. Click **Add Partner** to start. Create and edit both use a two-step flow: **Basics** first, then **Reporting & Integrations**.
+
+### Step 1 — Partner Basics
+
+- **Partner Name*** — required (e.g. `FC Barcelona`, `UEFA`, `Camp Nou`).
+- **Partner Emoji*** — required; chosen via the emoji selector.
+- **Show emoji in reports and displays** — checkbox; uncheck to hide the emoji while keeping it stored (`showEmoji`, defaults to true).
+- **TheSportsDB** — search and link a sports team to auto-populate logo, colours, stadium, and hashtags. See [Sport databases](guides-tutorial-sport-databases.md).
+- **Hashtags** — general and categorized hashtags via the unified hashtag input. See [Hashtags & filters](guides-tutorial-hashtags-filters.md).
+
+Click **Continue to Reporting** to advance.
+
+### Step 2 — Reporting & Integrations
+
+- **Bitly Links** — attach tracking links (many-to-many). See [Bitly](guides-tutorial-bitly.md).
+- **Report Visual Style** — the report colour theme (`styleId`); leave as "Use Default Style" to inherit. See [Report themes](guides-tutorial-report-themes.md).
+- **Report Template** — the default report layout for this partner and its events (`reportTemplateId`). See [Reports](guides-tutorial-reports.md).
+- **Clicker Set** — the default live-capture layout (`clickerSetId`). A starred entry marks the system default. See [Clicker sets](guides-tutorial-clicker-sets.md).
+- **Auto-create + connect Google Sheet** (create flow only) — optionally provision a new Google Sheet, write headers, and connect it in one step. You still share the sheet with the partner's editors afterwards. See [Google Sheets](guides-tutorial-google-sheets.md).
+
+Click **Create Partner** to finish. On success a confirmation card offers **Open Editor**, **Open Partner Report**, **Open Analytics**, and (if provisioned) **Open Google Sheet**.
+
+### Key partner fields
+
+| Field | Purpose |
+|-------|---------|
+| `name`, `emoji`, `showEmoji` | Identity and display |
+| `hashtags`, `categorizedHashtags` | Tagging and filtering, inherited by events |
+| `logoUrl` | CDN-hosted logo (from TheSportsDB badge or an upload) |
+| `sportsDb` | Full TheSportsDB team profile (venue, league, country, badge, etc.) |
+| `clickerSetId` | Default clicker layout for capture |
+| `styleId` | Default report visual theme |
+| `reportTemplateId` | Default report layout/template |
+| `googleSheetsUrl` | Canonical linked Google Sheet |
+| `viewSlug` | Shareable slug for the public partner report/editor |
+| `showOnlyTeam1Events` | Restrict the partner report to home/Team 1 appearances (edit flow) |
+
+> Note: The current partner record and admin form do **not** expose separate `cityId` / `countryId` fields. Geography comes from the linked TheSportsDB profile (`sportsDb.strCountry`, `sportsDb.strStadiumLocation`) rather than dedicated city/country IDs. Treat those as sports-DB-derived, not first-class partner fields.
+
+## Managing it
+
+### Recommended setup order
+
+The two-step flow is deliberately identity-first, integrations-second. A dependable order:
+
+1. **Basics** — name, emoji, and (if it is a sports club) the TheSportsDB link so logo, venue, and league hashtags auto-populate.
+2. **Hashtags** — confirm the general and categorized tags the partner's events should inherit.
+3. **Reporting defaults** — choose the report template, visual style, and clicker set so new events start correctly.
+4. **Distribution** — attach Bitly links and connect a Google Sheet if the partner maintains events externally.
+5. **Organisation** — have a superadmin assign the partner to its organisation from `/admin/organizations`.
+
+### Editing a partner
+
+Use the row's edit action to reopen the two-step modal. The edit flow adds a few things the create flow does not:
+
+- **Partner UUID** — read-only identifier shown in Basics, useful for referencing the partner in Sheets or analytics.
+- **Only Include Local/Home Events (Team 1)** — when enabled, the partner report only aggregates and lists events where the partner is Team 1 / the home side (`showOnlyTeam1Events`).
+- **Google Sheet URL or ID** with inline connect and sync controls (see below).
+
+### Assigning to an organisation
+
+Partners are assigned to an organisation from the **Organizations** page, not from the partner form. A superadmin opens `/admin/organizations`, clicks **Manage Members** on the target organisation, adds the partner, and saves. A partner belongs to exactly one organisation. See [Organisations](guides-tutorial-organisations.md).
+
+### Partner report and report variants
+
+- The public partner report lives at `/partner-report/[slug]`, where `[slug]` is the partner's `viewSlug` (falling back to its ID).
+- The report-variants workspace is at `/admin/partners/[id]/reports`. `DEFAULT` is always the canonical all-time partner report; every custom variant starts as a duplicate of `DEFAULT`.
+- Create a variant with **+ Create Report Variant**: give it a name and a **Time Period** — All Time, This Month, Last 30 Days, This Year, Last Year, or a **Custom Time Period** with start/end dates.
+- Each variant carries a status (`draft` / `published` / `archived`) and inline actions: **Open Report**, **Edit Report**, **Share Report**, **Rename**, **Set Default**, **Publish**, **Archive**. A non-default variant opens at `/partner-report/[slug]?variant=[variant-slug]`.
+
+See [Report variants](guides-tutorial-report-variants.md).
+
+### Enriching a partner from a sports database
+
+In the partner modal, use the **TheSportsDB** search to find and link the club. Linking pulls in the badge (logo), venue, league, country, and founding year. If the team is not found (the free API has gaps), click **Can't find it? Enter manually** and fill **Venue Name**, **Venue Capacity**, **League Name**, **Country**, **Founded Year**, and a **Logo URL** (or upload a file — uploaded logos are hosted on ImgBB and the hosted URL is stored back). See [Sport databases](guides-tutorial-sport-databases.md).
+
+### Connecting a Google Sheet
+
+In the edit modal's Reporting & Integrations step:
+
+- Paste a **Google Sheet URL or ID**, or click **Create & Connect New Google Sheet** to provision a fresh one.
+- **Connect & Setup Google Sheet** renames the tab, adds columns, populates existing events, and connects the sheet.
+- **Sheet → Mess** pulls rows from the sheet into messmass; **Mess → Sheet** pushes events out to the sheet.
+- **Prefix UUID in Sheet Title** stamps the partner UUID onto the spreadsheet title for traceability.
+
+After connecting, share the sheet with the partner's editors so they can maintain event rows themselves. See [Google Sheets](guides-tutorial-google-sheets.md).
+
+## Gotchas & good practice
+
+- **Name and emoji are mandatory.** The form blocks submission until both are set, on create and edit.
+- **Deleting a partner does not delete its events.** There is no cascade — events created from the partner keep their inherited metadata, and Bitly links (many-to-many) are untouched. Delete is a confirm-and-remove action, so treat it as intentional.
+- **Set defaults on the partner, not per event.** Report template, style, clicker set, hashtags, and logo defined here flow down to new events, which is the whole point of the partner as a template.
+- **Organisation assignment is elsewhere.** Do not look for an org picker in the partner form — it lives on the Organizations page and is superadmin-only.
+- **`showOnlyTeam1Events` reshapes the report.** Enabling it removes away/Team 2 appearances from both the aggregate stats and the event list — expect the numbers to drop.
+
+> Note: Partners are mirrored into the **Camera app** as shared identities. When a messmass event is created for a partner, messmass ensures a matching Camera partner (creating it under the partner's Camera organisation if needed) and stamps the Camera partner ID back onto the record. Ops helpers can also link existing partners or backfill events. See [Camera app](guides-tutorial-camera-app.md).
+
+## How it connects
+
+- **Organisations** group partners and drive org-level reporting — see [Organisations](guides-tutorial-organisations.md).
+- **Events** are created under a partner and inherit its defaults — see [Events](guides-tutorial-events.md).
+- Reporting defaults reference **templates**, **themes**, **clicker sets**, and **variants** — see [Reports](guides-tutorial-reports.md), [Report themes](guides-tutorial-report-themes.md), [Clicker sets](guides-tutorial-clicker-sets.md), and [Report variants](guides-tutorial-report-variants.md).
+- Integrations connect through **TheSportsDB**, **Bitly**, and **Google Sheets** — see [Sport databases](guides-tutorial-sport-databases.md), [Bitly](guides-tutorial-bitly.md), and the reference [features: Google Sheets integration](../features/features-google-sheets-integration.md).
+- A deeper technical reference lives at [features: Partners system guide](../features/features-partners-system-guide.md).
+
+## Screenshots
+_Screenshots to be added._
+
+## Related tutorials
+
+- [Tutorials index](guides-tutorials-index.md)
+- [Getting started](guides-tutorial-getting-started.md)
+- [Organisations](guides-tutorial-organisations.md)
+- [Events](guides-tutorial-events.md)
+- [Sport databases](guides-tutorial-sport-databases.md)
+- [Google Sheets](guides-tutorial-google-sheets.md)
+- [Report variants](guides-tutorial-report-variants.md)
+- [Report themes](guides-tutorial-report-themes.md)
+- [Reports](guides-tutorial-reports.md)
+- [Clicker sets](guides-tutorial-clicker-sets.md)
+- [Camera app](guides-tutorial-camera-app.md)

--- a/docs/guides/guides-tutorial-report-themes.md
+++ b/docs/guides/guides-tutorial-report-themes.md
@@ -1,0 +1,154 @@
+# Tutorial: Report themes & styles
+Status: Active
+Last Updated: 2026-07-20T00:00:00.000Z
+Canonical: Yes
+Owner: Documentation
+
+> Audience: Internal operators & implementation partners · Prerequisites: Admin access to the Reporting workspace · Related: [guides-tutorial-reports.md](guides-tutorial-reports.md), [guides-tutorial-report-variants.md](guides-tutorial-report-variants.md), [guides-tutorial-partners.md](guides-tutorial-partners.md)
+
+## What it is & why it matters
+
+A **report style** (the admin area calls them **Report Themes**) is the colour-and-typography skin applied to a rendered report. Where a Report Template decides *what* appears and *how it is arranged* (see [guides-tutorial-reports.md](guides-tutorial-reports.md)), a style decides *how it looks*: the hero background, chart colours, KPI icon colour, pie and bar palettes, tooltip colours, the report font, and a set of optional spacing/size values.
+
+Styles are **reusable**. You build a theme once — say a partner's brand colours — and attach it wherever that brand should appear. One theme can skin many events, so rebranding is a single edit rather than a per-event chore.
+
+- **Admin UI:** `/admin/styles` (the list) and `/admin/styles/[id]` (the editor).
+- **Stored in:** the `report_styles` collection.
+
+> Note: `page_styles_enhanced` is a **legacy** style system that has been **superseded by `report_styles`**. New and edited themes live in `report_styles`. If you encounter `page_styles_enhanced`, treat it as historical — do not build new themes there.
+
+### Two colour scopes in one theme
+
+A single theme actually carries two sets of colours:
+
+- **Report colours (26 fields)** — everything the report page itself uses: hero, chart containers, chart typography, KPI icon, bar and pie palettes, and chart states. These are the fields you will touch most.
+- **Landing colours (9 fields)** — the public landing surface (hero gradient, hero text, CTA borders, page background). Setting these lets a theme brand the landing page as well as the report.
+
+Together that is 35 colour fields, plus the font family and the optional dimension/surface values. You can safely ignore the landing colours if a theme is only ever used for reports.
+
+## Before you start
+
+- Be signed in to the admin area with access to the Reporting workspace. See [guides-tutorial-authentication-sso.md](guides-tutorial-authentication-sso.md).
+- Have the brand's colour values ready (hex codes). The editor stores colours as 8-character hex with an alpha channel — `#RRGGBBAA` — so you can set transparency, not just the base colour.
+- Know where the theme should apply: a single event, a whole partner, or as a template default. That decision drives assignment, covered under [How it connects](#how-it-connects).
+- If the font you want is not in the dropdown, it must first exist in the platform's font list — the editor only offers fonts already registered.
+
+## Step by step
+
+### 1. Open the themes list
+
+Go to `/admin/styles`. The page header reads **"Report Themes"** with the subtitle *"Manage reusable visual themes for report pages"*. Each existing theme is a card showing its name, an optional description, a small swatch preview (Hero, Chart, Icon, Bar 1, Bar 2, Pie), and the last-updated date.
+
+### 2. Create a new theme
+
+Click **"Create New Style"** (top-right of the list). This opens the editor at `/admin/styles/new`. The editor is a split screen:
+
+- **Left — Live Preview:** a miniature report that repaints on every change.
+- **Right — Colors:** the form.
+
+Start with the basics at the top of the form:
+
+- **Style Name \*** — required; this is how you will recognise the theme later.
+- **Description** — optional free text.
+- **Font Family** — a dropdown populated from the platform's registered fonts. This font is applied to all text in the report.
+
+### 3. Set the colours
+
+Below the basics, the colour fields are grouped into categories. There are **26 report colour fields** in these groups:
+
+- **Hero Section (5)** — Hero Background, Heading Color, Export Button BG, Export Button Text, Export Button Hover.
+- **Chart Container (2)** — Chart Background, Chart Border.
+- **Chart Typography (4)** — Chart Title, Chart Label, Chart Value, Text Content.
+- **KPI Charts (1)** — KPI Icon Color.
+- **Bar Charts (5)** — Bar Color 1 through Bar Color 5.
+- **Pie Charts (3)** — Pie Color 1, Pie Color 2, Pie Border.
+- **Chart States (6)** — No Data Background/Border/Text, Error Background/Text, Tooltip Background/Text (the empty-state, error, and tooltip colours).
+
+Each field is a colour picker; the preview on the left updates immediately so you can judge combinations without saving.
+
+There is a further group of **9 Landing colours** (hero gradient start/mid/end, hero text, muted text, CTA borders and hover states, page background). These skin the public landing surface as well as the report; set them only if your theme should reach the landing page too.
+
+### 4. (Optional) Set dimensions & surfaces
+
+Under **"Dimensions & surfaces"** the editor exposes optional length/size fields. Leave them blank to inherit the platform defaults; fill one in to override it. They fall into three groups:
+
+- **Landing dimensions** — section padding, hero padding, card widths, FAQ/paragraph max widths, icon size.
+- **Surfaces** — card border radius and card shadow (these affect report cards too).
+- **Landing typography** — block title, block value, and block icon sizes.
+
+Each field carries a placeholder showing the expected format, for example `3.5rem`, `0.75rem`, or `65ch`.
+
+### 5. Save
+
+Click **"Save Style"**. Before saving, the editor validates that the name is present and every colour is a valid hex value; if something is off, the status line shows the first problem. On a successful create you are redirected to the theme's own edit page (`/admin/styles/<id>`), from which further edits save in place.
+
+### 6. Assign the theme
+
+Saving a theme does not display it anywhere yet. Attach it to an event, partner, template or filter/hashtag — see [How it connects](#how-it-connects) — and it takes effect on the next report render.
+
+### 7. Worked example: a partner brand theme
+
+Suppose a partner uses a dark navy hero with a lime accent.
+
+1. Create a theme named *Acme — Brand*.
+2. Set **Hero Background** to the navy (include an alpha byte if you want slight translucency, e.g. `#0f172aff`).
+3. Set **Heading Color** to a light value so the event title reads against navy.
+4. Set **Bar Color 1** and **Pie Color 1** to the lime accent, and pick a complementary **Bar Color 2**–**Bar Color 5** ramp.
+5. Set **KPI Icon Color** to the same lime so tiles feel consistent.
+6. Choose the brand **Font Family** from the dropdown, watch the left preview, then **Save Style**.
+7. Assign *Acme — Brand* to the partner. Every event under that partner now renders in brand colours unless an individual event overrides the style.
+
+## Managing it
+
+**Edit.** From the list, click **Edit** on a card (or open `/admin/styles/[id]`). The header shows **"Edit: <name>"**. Adjust anything and click **Save Style**; changes propagate to every report that resolves to this theme.
+
+**Duplicate a look manually.** There is no one-click "copy theme" button. To base a new theme on an existing one, open the original, note its values (or open it in a second tab as reference), then build the new theme in `/admin/styles/new`. Give it a clearly different name.
+
+**Delete.** Each card has a delete action. It asks to confirm — *"Delete style ... This cannot be undone."* Deletion is permanent, so before removing a theme, make sure nothing still points at it; otherwise those reports fall back down the style hierarchy (described below) and may look different than expected.
+
+**Live preview is your safety net.** Because the preview repaints continuously, treat it as the source of truth while editing — especially for transparency (the alpha byte) and for dark hero backgrounds where low-contrast text can hide.
+
+**Chart-state colours are easy to forget.** The six Chart States fields (no-data background/border/text, error background/text, tooltip background/text) only show up in edge cases — an empty chart, an error, or a hover tooltip. They still ship with every theme, so set them to something on-brand rather than leaving jarring defaults that only appear at the worst moment.
+
+**Dimensions inherit unless overridden.** A blank dimension field means "use the platform default". This is usually what you want — only override a spacing, radius, shadow or font-size value when the brand genuinely requires it, and use the placeholder format shown in each field.
+
+## Gotchas & good practice
+
+- **Colours are 8-character hex.** `#RRGGBBAA`. A 6-character value is accepted and normalised to fully opaque (`ff` alpha). If a colour looks washed out, check its alpha byte.
+- **A theme is skin only.** It never changes which charts or blocks appear — that is the template's job ([guides-tutorial-reports.md](guides-tutorial-reports.md)). If a chart is missing, fix the template, not the theme.
+- **Font must exist first.** The dropdown lists only registered fonts. Typing a font name elsewhere will not add it.
+- **Assign, don't just save.** A saved but unassigned theme is invisible. Confirm the event/partner/template actually references it.
+- **Deleting is destructive and silent downstream.** Reports do not error when their theme is deleted; they quietly drop to the next level of the hierarchy. Reassign before deleting.
+- **Landing colours reach beyond the report.** The 9 landing fields also affect the public landing surface — only fill them if that is intended.
+
+## How it connects
+
+**Style resolution (precedence).** When a report renders, messmass resolves a single style by taking the **first one that is set**, in this order:
+
+1. **Project / event style** — the style set directly on the event. Highest priority; overrides everything for that one event's report.
+2. **Partner style** — the partner's style. Applies to all of that partner's events that do not set their own, and to the partner report itself.
+3. **Template style** — the default style attached to the report template. Used when neither the event nor the partner specifies one.
+
+In short: **project style › partner style › template style.** The first non-empty value wins.
+
+**Filter and hashtag reports** do not add a new style tier. They resolve a template (see [guides-tutorial-hashtags-filters.md](guides-tutorial-hashtags-filters.md)) and inherit **that template's style** (or the partner/project style where that resolution path applies).
+
+**Variants** can carry their own style, letting one owner publish the same report in two different looks. See [guides-tutorial-report-variants.md](guides-tutorial-report-variants.md).
+
+**Where you assign a style:**
+- **Event:** on the event record — see [guides-tutorial-events.md](guides-tutorial-events.md).
+- **Partner:** on the partner record — see [guides-tutorial-partners.md](guides-tutorial-partners.md).
+- **Organisation:** on the organisation — see [guides-tutorial-organisations.md](guides-tutorial-organisations.md).
+
+## Screenshots
+_Screenshots to be added._
+
+## Related tutorials
+
+- [guides-tutorial-reports.md](guides-tutorial-reports.md) — the templates and blocks a theme skins
+- [guides-tutorial-report-variants.md](guides-tutorial-report-variants.md) — per-variant styles
+- [guides-tutorial-partners.md](guides-tutorial-partners.md) — assigning a partner style
+- [guides-tutorial-events.md](guides-tutorial-events.md) — assigning an event style
+- [guides-tutorial-hashtags-filters.md](guides-tutorial-hashtags-filters.md) — how filter/hashtag reports pick up a style
+- [guides-tutorial-sharing-access.md](guides-tutorial-sharing-access.md) — publishing a themed report
+- [guides-tutorials-index.md](guides-tutorials-index.md) — full tutorial index

--- a/docs/guides/guides-tutorial-report-variants.md
+++ b/docs/guides/guides-tutorial-report-variants.md
@@ -1,0 +1,147 @@
+# Tutorial: Report variants
+Status: Active
+Last Updated: 2026-07-20T00:00:00.000Z
+Canonical: Yes
+Owner: Documentation
+
+> Audience: Internal operators & implementation partners · Prerequisites: A partner or organisation that already has a working report · Related: [guides-tutorial-reports.md](guides-tutorial-reports.md), [guides-tutorial-report-themes.md](guides-tutorial-report-themes.md), [guides-tutorial-sharing-access.md](guides-tutorial-sharing-access.md)
+
+## What it is & why it matters
+
+A **report variant** is a saved, time-scoped version of one owner's report. The same partner or organisation can publish several: an all-time overview, a "this year" cut, a "last 30 days" snapshot, or a custom date range for one campaign — each with its own shareable link.
+
+Without variants you would have one report per owner and would have to re-filter it by hand every time someone asked for a different window. Variants let you prepare each cut once, publish it, and hand out a stable URL.
+
+Every variant belongs to an **owner**. In the model an owner is an organisation, a partner, a hashtag, or a filter. The two places you actively manage variants are:
+
+- **Partner reports:** `/admin/partners/[id]/reports`
+- **Organisation reports:** `/admin/organizations/[id]/reports`
+
+Both screens work the same way; the examples below apply to either.
+
+## Before you start
+
+- The owner needs a working report already — a resolved template and (usually) a style. If the partner or organisation report does not render on its own yet, sort that first via [guides-tutorial-reports.md](guides-tutorial-reports.md).
+- Be signed in with admin access to the Reporting workspace. See [guides-tutorial-authentication-sso.md](guides-tutorial-authentication-sso.md).
+- Decide the **time window** each variant should cover before you create it (all-time, this month, last 30 days, this year, last year, or a custom start/end). You can change it later, but naming a variant after its window keeps the list readable.
+
+## Step by step
+
+### 1. Open the reports workspace
+
+Go to `/admin/partners/[id]/reports` (or `/admin/organizations/[id]/reports`). The header shows the owner's name plus a summary strip: **Default Report**, **Variants** (count), and **Published** (count). A note reminds you that *DEFAULT always stays the canonical all-time report, and every custom variant starts as a duplicate of DEFAULT.*
+
+### 2. Understand the virtual DEFAULT
+
+Before you create anything, the list already shows one entry: **DEFAULT**. This is a *virtual* variant — it is not stored as a document yet, it simply represents the owner's canonical, all-time report. It is always marked **DEFAULT**, always **published**, and always uses the **All Time** period.
+
+The header's **"Open Default Report"** button opens exactly this report. You cannot rename, archive, or re-scope the virtual DEFAULT — it is the baseline every custom variant is copied from.
+
+### 3. Create a custom variant
+
+Click **"+ Create Report Variant"** to open the create dialog and fill in:
+
+- **Variant Name** (required) — e.g. *Renewal 2026* or *CHL This Year*.
+- **Time Period** — one of six presets:
+  - **All Time** (`all_time`)
+  - **This Month** (`this_month`)
+  - **Last 30 Days** (`last_30_days`)
+  - **This Year** (`this_year`)
+  - **Last Year** (`last_year`)
+  - **Custom Time Period** (`custom`)
+- **Start Date / End Date** — shown only when the period is **Custom Time Period**. Both are required, and the end date must be on or after the start date.
+
+Submit with **"Create Variant"**. The new variant is created as a **duplicate of DEFAULT** — it inherits DEFAULT's template, style, logo, emoji and display toggles — then applies the time window you chose. It starts in **draft** status. Its URL slug is generated from the name (and de-duplicated automatically if a slug already exists, so two "Renewal 2026" variants become distinct).
+
+### 4. Review the variant card
+
+Each stored variant appears as a card showing:
+
+- A **DEFAULT** or **CUSTOM** badge, plus a status badge (**draft**, **published**, or **archived**).
+- The variant name and its resolved period label (a custom range shows as *start to end*).
+
+### 5. Publish it
+
+New custom variants are **draft** until you publish. Click **Publish** on the card to move it to **published**. Only published variants are meant to be shared onward; draft is your staging state.
+
+### 6. Open, edit and share
+
+Three actions on every card:
+
+- **Open Report** — opens the rendered report for that variant in a new tab. The default opens at the plain report URL; a custom variant appends `?variant=<slug>`.
+- **Edit Report** — deep-links into the report editor for that exact variant (`…-edit/[id]?variant=<slug>`), so text, images, style and template edits land on the right version.
+- **Share Report** — opens the share dialog for that variant (covered under [How it connects](#how-it-connects)).
+
+### 7. Worked example: a "This Year" cut for a partner
+
+1. On `/admin/partners/[id]/reports`, click **"+ Create Report Variant"**.
+2. Name it *2026 Season*, choose **This Year**, and create it. It appears as a **CUSTOM**, **draft** card scoped to the current year.
+3. Click **Edit Report** and adjust any variant-specific text or images; the editor opens at `…-edit/[id]?variant=2026-season`.
+4. Click **Publish** to move it from draft to published.
+5. Click **Share Report** and distribute the link with its page password.
+6. Next year, rather than deleting it, **Archive** *2026 Season* and create *2027 Season* — the old cut stays available if anyone needs last year's numbers.
+
+## Status lifecycle at a glance
+
+A stored variant is always in one of three states:
+
+- **draft** — the starting state for every newly created custom variant. Not intended for distribution.
+- **published** — live; this is the state you share. **Publish** moves a draft or archived variant here.
+- **archived** — retired but preserved. **Archive** moves a published variant here; it keeps its slug and settings and can be re-published later.
+
+The virtual **DEFAULT** is always **published** and cannot be archived. Promoting a custom variant with **Set Default** also publishes it in the same step.
+
+## Managing it
+
+**Rename.** On a custom card, **Rename** prompts for a new name. (DEFAULT cannot be renamed.)
+
+**Set Default.** **Set Default** on a custom variant promotes it: it becomes the owner's default *and* is published in the same action, and the previous default is unset. Note this changes what **"Open Default Report"** returns for everyone.
+
+**Publish / Archive.** A variant moves between **published** and **archived** from the card:
+- **Publish** takes a draft or archived variant live.
+- **Archive** retires a published variant without destroying it.
+
+The archived state is how you take a report out of circulation while keeping its configuration and history.
+
+### There is no delete
+
+**Variants cannot be deleted.** There is no delete button anywhere on these screens — the retirement path is **Archive**, not removal. An archived variant stays in the list, keeps its slug and settings, and can be re-published later if you need it back. Plan naming and archiving accordingly, because the list only ever grows.
+
+## Gotchas & good practice
+
+- **Archive is the only "remove".** If a variant is stale, archive it. Do not expect a delete button — there isn't one, and archiving is deliberately reversible.
+- **DEFAULT is virtual until you promote something.** Until a stored variant is Set as Default, the DEFAULT row is a stand-in for the canonical all-time report. Promoting a custom variant to default replaces what the default link shows.
+- **Custom variants inherit DEFAULT at creation time.** They copy DEFAULT's template, style and display settings *when created*. Later changes to the baseline do not retroactively flow into existing variants — edit each variant if you need it updated.
+- **Draft ≠ shared.** A freshly created variant is draft. Share links resolve the variant, but keep drafts unpublished until the content is final.
+- **Custom range validation is strict.** For a custom period, both dates are required and the end must not precede the start; the form blocks submission otherwise.
+- **Slugs are auto-generated and unique.** You name the variant; messmass derives and de-duplicates the slug. The slug is what appears in the `?variant=` URL and in the share identifier.
+
+## How it connects
+
+**Sharing uses a page password.** The **Share Report** action opens the standard share dialog. Under the hood a variant is shared with a compound page identifier: the owner's base page id plus its variant slug, written as **`id::variant=<slug>`**. The DEFAULT variant shares under the plain base id (no `::variant=` suffix). Access is gated by a **page password**, exactly like other shared report pages — see [guides-tutorial-sharing-access.md](guides-tutorial-sharing-access.md) for how page passwords are set and distributed.
+
+**Variants sit on top of templates and styles.** A variant does not replace the report structure; it reuses the owner's resolved **template** (see [guides-tutorial-reports.md](guides-tutorial-reports.md)) and may carry its own **style** (see [guides-tutorial-report-themes.md](guides-tutorial-report-themes.md)) and time window. Think of the layers as: template = structure, style = look, variant = which time window and which published cut.
+
+**Owners.** The two managed surfaces are **partners** ([guides-tutorial-partners.md](guides-tutorial-partners.md)) and **organisations** ([guides-tutorial-organisations.md](guides-tutorial-organisations.md)). The underlying model also recognises hashtag and filter owners; see [guides-tutorial-hashtags-filters.md](guides-tutorial-hashtags-filters.md).
+
+**URLs at a glance.** The DEFAULT variant uses the plain report and editor URLs; a custom variant appends `?variant=<slug>`:
+
+| Owner | Report (DEFAULT) | Report (custom) | Editor (custom) |
+|-------|------------------|-----------------|-----------------|
+| Partner | `/partner-report/<slug>` | `/partner-report/<slug>?variant=<slug>` | `/partner-edit/<slug>?variant=<slug>` |
+| Organisation | `/organization-report/<id>` | `/organization-report/<id>?variant=<slug>` | `/organization-edit/<id>?variant=<slug>` |
+
+You rarely type these by hand — the **Open Report** and **Edit Report** buttons build them for you — but recognising the pattern helps when someone pastes you a link and asks which variant it points at.
+
+## Screenshots
+_Screenshots to be added._
+
+## Related tutorials
+
+- [guides-tutorial-reports.md](guides-tutorial-reports.md) — the template a variant renders
+- [guides-tutorial-report-themes.md](guides-tutorial-report-themes.md) — the style a variant can carry
+- [guides-tutorial-sharing-access.md](guides-tutorial-sharing-access.md) — page passwords and share links
+- [guides-tutorial-partners.md](guides-tutorial-partners.md) — partner-owned reports
+- [guides-tutorial-organisations.md](guides-tutorial-organisations.md) — organisation-owned reports
+- [guides-tutorial-hashtags-filters.md](guides-tutorial-hashtags-filters.md) — hashtag and filter owners
+- [guides-tutorials-index.md](guides-tutorials-index.md) — full tutorial index

--- a/docs/guides/guides-tutorial-reports.md
+++ b/docs/guides/guides-tutorial-reports.md
@@ -1,0 +1,185 @@
+# Tutorial: Building reports
+Status: Active
+Last Updated: 2026-07-20T00:00:00.000Z
+Canonical: Yes
+Owner: Documentation
+
+> Audience: Internal operators & implementation partners · Prerequisites: Admin access to the Reporting workspace; at least one event with data · Related: [guides-tutorial-report-themes.md](guides-tutorial-report-themes.md), [guides-tutorial-report-variants.md](guides-tutorial-report-variants.md), [guides-tutorial-charts-formulas.md](guides-tutorial-charts-formulas.md)
+
+## What it is & why it matters
+
+A messmass report is what a partner or organisation actually sees: a page of charts, KPIs, images and text arranged in a repeatable layout. You do not hand-build that page for every event. Instead you build a **Report Template** once, and every event, partner or organisation that resolves to that template renders the same structure with its own data.
+
+The report stack has three nested pieces. Learn these words first — the rest of the tutorial uses them constantly:
+
+- **Report Template** — the top-level layout. Built in the **Report Builder** at `/admin/visualization`. A template owns its responsive grid, its report header (HERO) settings, and an ordered list of blocks. Stored in the `report_templates` collection.
+- **Data Block** — a horizontal band inside a template. A block groups a few charts together and can show its own title. Stored in the `data_blocks` collection.
+- **Chart** — a single visual unit inside a block (a KPI tile, a pie, a bar chart, a text panel, a table, an image). Charts are defined elsewhere (see [guides-tutorial-charts-formulas.md](guides-tutorial-charts-formulas.md)); a block only references them and decides how wide each one sits.
+
+So the composition is: **Template → contains ordered Data Blocks → each Block contains Charts.**
+
+> Note: Two collection names cause confusion. `reports_v12` is **not** a live collection — ignore it entirely if you ever see it referenced. The older `reports` collection is **legacy and effectively read-only**; the current Report Builder does not write to it. Everything you do in this tutorial writes to `report_templates` and `data_blocks`.
+
+## Before you start
+
+- You need to be signed in to the admin area with rights to the Reporting workspace. See [guides-tutorial-authentication-sso.md](guides-tutorial-authentication-sso.md) if you cannot reach `/admin`.
+- Have at least one event with real numbers, so previews render meaningfully. See [guides-tutorial-events.md](guides-tutorial-events.md) and [guides-tutorial-collecting-data.md](guides-tutorial-collecting-data.md).
+- Know which charts already exist. The builder only lets you drop in charts that have been defined; it does not create charts. See [guides-tutorial-charts-formulas.md](guides-tutorial-charts-formulas.md).
+- Decide the **scope** of the template you are about to build: is it a fallback for every event (`event`), specific to one partner (`partner`), or the global default (`global`)? You can change the type later, but picking it up front keeps the template list readable.
+
+## Step by step
+
+### 1. Open the Report Builder
+
+Go to `/admin/visualization`. The page header reads **"👁️ Report Builder"** with the subtitle *"Manage report blocks, chart layouts, and template composition"*. The builder remembers the last template you edited, so on later visits it reopens where you left off.
+
+### 2. Pick or create a template
+
+Use the template selector near the top to switch between existing templates. Each entry shows its name and type, and the current default is marked with a star.
+
+To create one, open **"➕ Create New Report Template"** and fill in:
+
+- **Template Name \*** — e.g. *Partner Annual Report* or *Event Dashboard*.
+- **Description** — optional, admin-facing only.
+- **Template Type \*** — one of three radio options: **Event Report** (`event`), **Partner Report** (`partner`), or **Global Default** (`global`).
+- **Set as default template** — a checkbox. Only one template can be the default at a time; ticking this clears the flag on whichever template held it before.
+
+A new template starts empty, with a responsive grid of **4 desktop / 2 tablet / 1 mobile** units and no blocks. It is auto-selected so you can start adding blocks immediately.
+
+### 3. Configure the report header (HERO)
+
+Open the **"🏒 HERO Block Settings"** section. These toggles control what appears in the banner at the top of the rendered report:
+
+- **Show Emoji** — display the event/partner emoji.
+- **Show Date Info (Created/Updated)** — show the created/updated dates.
+- **Show Export Options (PDF/Excel buttons)** — show the download buttons.
+
+Below that, **alignment settings** keep blocks tidy across a row: **Align Titles**, **Align Descriptions**, **Align Charts**, and an optional **Minimum Element Height (px)**. These changes save automatically and apply to every report that uses this template.
+
+### 4. Set the responsive grid
+
+A template renders on three widths, each with its own column budget:
+
+- **Mobile** — 2 units per row
+- **Tablet** — 3 units per row
+- **Desktop** — up to 6 units per row (block-configurable)
+
+Think in **units**, not pixels. A unit is one column of horizontal space. A chart set to unit size 2 spans two columns.
+
+### 5. Add data blocks
+
+In the **"Data Visualization Blocks"** section, the current block count shows as *Current Blocks (N)*. Click **"➕ New Block"** to open **"➕ Create New Data Block"**:
+
+- **Block Name** — e.g. *Main Dashboard* or *Performance Metrics*.
+- **Order** — where the block sits vertically in the template (0 is first).
+
+Save it, and the block is created **and** attached to the current template in one step.
+
+### 6. Add charts to a block and size them
+
+Expand a block with its **"⚙️ Show Settings"** toggle (it flips to **"⚙️ Hide Settings"**). Inside, you assign charts from the available list and give each one a layout:
+
+- **Unit size** — `1` or `2` columns of horizontal space.
+- **Aspect ratio** — the content shape: `1:1`, `2:1`, `16:9`, or `9:16`.
+
+Allowed combinations depend on the chart type:
+
+| Chart type | Unit size | Aspect ratio |
+|------------|-----------|--------------|
+| KPI        | 1         | 1:1 |
+| Pie        | 1         | 1:1 |
+| Bar        | 1 or 2    | 1:1 or 2:1 |
+| Text       | 1 or 2    | 1:1 or 2:1 |
+| Table      | 1 or 2    | 1:1 or 2:1 |
+| Image      | 1 or 2    | 1:1, 16:9, or 9:16 |
+
+The editor only offers valid options, and it keeps unit size and aspect ratio consistent — for example, an image at 16:9 becomes 2 units wide, and a bar at 2:1 becomes 2 units wide.
+
+**Block capacity:** the unit sizes of all charts in a block must total **4 or less**. If the sum exceeds 4, the save is blocked and the editor tells you the current total. Split the charts across two blocks if you hit the limit.
+
+### 7. Preview as you go
+
+The builder renders a live WYSIWYG preview using the same grid and calculation pipeline as the real report pages, seeded with sample data. What you see in the preview is what a real event will render, minus its own numbers.
+
+### 8. Assign the template to something
+
+A template does nothing until an event, partner or organisation points at it:
+
+- **Event (project):** set the template on the event itself when creating or editing it. See [guides-tutorial-events.md](guides-tutorial-events.md).
+- **Partner:** set the template on the partner. Every event under that partner then falls back to it. See [guides-tutorial-partners.md](guides-tutorial-partners.md).
+- **Organisation:** set on the organisation. See [guides-tutorial-organisations.md](guides-tutorial-organisations.md).
+
+### 9. Worked example: a two-block event template
+
+Suppose you want a simple event report with a headline row and a demographics row.
+
+1. Create a template named *Event Dashboard*, type **Event Report**, and leave it as the default if this should be the fallback for all events.
+2. In HERO settings, keep **Show Emoji** and **Show Export Options** on; the header then carries the event emoji and the PDF/Excel buttons.
+3. Add a block named *Headline*. Give it two KPI charts (each fixed at 1 unit) and one bar chart at 2 units. Total = `1 + 1 + 2 = 4` units — exactly the block cap.
+4. Add a second block named *Audience*, ordered after the first. Drop in two pie charts (1 unit each) and one 2-wide bar. Again 4 units.
+5. Watch the live preview arrange both rows using the responsive grid, then assign *Event Dashboard* to an event and open its report.
+
+If you later try to add a fifth unit to either block, the save is rejected until you free up space or move a chart to a new block.
+
+## Managing it
+
+**Manage an existing template.** From the builder, open **"📝 Manage Report Template: <name>"**. This modal shows **Template Usage** — how many projects and partners currently point at this template — and lets you **rename** or **copy** it.
+
+**Copying.** A copy duplicates the template *and* its data blocks, so the copy is fully independent — editing the copy never touches the original. Copies are never marked as default. Use a copy as a safe starting point when you want a variation without risking a live template.
+
+**Deleting.** Deletion is guarded on purpose. Confirm through the **"Delete Report Template?"** dialog. Two rules stop accidental breakage:
+
+- You **cannot delete the default template**.
+- You **cannot delete a template that is still assigned** to any project or partner. The error tells you how many of each are still attached. Reassign them first, then delete.
+
+**Reordering and removing blocks.** Block order is stored per template, so dragging or reordering blocks in the builder changes only this template's layout — not the blocks themselves. Removing a block from a template detaches it from that template; because blocks can be shared, prefer copying a template when you want an isolated set of blocks to edit freely.
+
+**Available chart types.** Blocks accept KPI, pie, bar, text, table, image, and value-chain charts. KPI and pie are fixed at 1 unit / 1:1; bar, text and table can go 1 or 2 units wide; images support 1:1, 16:9 and 9:16. The builder only ever offers the combinations a given chart type allows.
+
+**The default flag is unique.** Setting any template as default clears the previous default automatically — there is always exactly one.
+
+## Gotchas & good practice
+
+- **Blocks are shared until you copy.** A data block belongs to whichever template(s) reference it. If you want an isolated variant, **copy the template** (which clones its blocks) rather than editing a block that another template also uses.
+- **Respect the 4-unit block cap.** It is the single most common reason a save is rejected. Two KPIs (1+1) plus a 2-wide bar (2) already fills a block.
+- **KPI and Pie are fixed.** They are always 1 unit at 1:1 — you cannot widen them. Reach for Bar/Text/Table/Image when you need a wide element.
+- **`event` type is the fallback, not a restriction.** The runtime does not filter the default template by type, and the assignment UI lets you attach any template type to events or partners. Type is mainly there to keep the list understandable.
+- **Only `partner1` is used for template inheritance.** If an event has two partners, the second partner is ignored when resolving which template to render.
+- **Ignore `reports_v12`; treat `reports` as read-only.** Only `report_templates` + `data_blocks` matter for anything you build here.
+
+## How it connects
+
+**Template resolution (precedence).** When a report page loads, messmass resolves which template to render by walking a fixed order and taking the first match:
+
+**For an event (project):**
+1. The event's own template, if set.
+2. Otherwise the template of the event's `partner1`.
+3. Otherwise the **global default** template (`isDefault = true`).
+4. Otherwise a hardcoded fallback (empty template) so the page never crashes.
+
+**For a partner report:**
+1. The partner's own template.
+2. Otherwise the global default.
+3. Otherwise the hardcoded fallback.
+
+In short: **project overrides partner, partner overrides default.** This is the same "Project → Partner → Default" hierarchy shown in the assignment screens.
+
+**Styles vs. templates.** A template controls *structure* (which blocks, which charts, how wide). It does **not** hard-own the colours and fonts — those come from a separate style/theme that is resolved with its own precedence. See [guides-tutorial-report-themes.md](guides-tutorial-report-themes.md).
+
+**Variants.** Partners and organisations can publish several time-scoped versions of the same report (this year, last 30 days, a custom range) on top of one template. See [guides-tutorial-report-variants.md](guides-tutorial-report-variants.md).
+
+**Sharing.** Reports are exposed to external viewers through shareable, password-protected links. See [guides-tutorial-sharing-access.md](guides-tutorial-sharing-access.md).
+
+## Screenshots
+_Screenshots to be added._
+
+## Related tutorials
+
+- [guides-tutorial-report-themes.md](guides-tutorial-report-themes.md) — colours, fonts and dimensions for reports
+- [guides-tutorial-report-variants.md](guides-tutorial-report-variants.md) — time-scoped versions of a report
+- [guides-tutorial-charts-formulas.md](guides-tutorial-charts-formulas.md) — how the charts you drop into blocks are defined
+- [guides-tutorial-events.md](guides-tutorial-events.md) — assigning a template to an event
+- [guides-tutorial-partners.md](guides-tutorial-partners.md) — assigning a template to a partner
+- [guides-tutorial-organisations.md](guides-tutorial-organisations.md) — organisation-level reporting
+- [guides-tutorial-sharing-access.md](guides-tutorial-sharing-access.md) — publishing a report to external viewers
+- [guides-tutorials-index.md](guides-tutorials-index.md) — full tutorial index

--- a/docs/guides/guides-tutorial-sharing-access.md
+++ b/docs/guides/guides-tutorial-sharing-access.md
@@ -1,0 +1,113 @@
+# Tutorial: Sharing reports & access control
+Status: Active
+Last Updated: 2026-07-20T00:00:00.000Z
+Canonical: Yes
+Owner: Documentation
+
+> Audience: Internal operators & implementation partners (partners can self-serve edit/view via link + password) · Prerequisites: An admin sign-in for the Share popup; an event, partner, organisation, filter, or hashtag page to share · Related: [Events](guides-tutorial-events.md) · [Collecting event data](guides-tutorial-collecting-data.md) · [Authentication & SSO](guides-tutorial-authentication-sso.md)
+
+## What it is & why it matters
+messmass has to let the right people see the right thing without handing everyone an admin account. It does this with two mechanisms:
+
+- **Unguessable UUID slugs** — report URLs contain a random UUID that cannot be guessed, so the link itself is the access control.
+- **Page passwords** — a per-page password that gates the surfaces that need an extra lock.
+
+The subtle part — and the part operators most often get wrong — is that **not every surface is gated the same way.** Reports are open to anyone with the link; filter, hashtag, and all edit surfaces require a password. Get this right and you share confidently; get it wrong and you either expose editing or block a viewer.
+
+## Before you start
+- You need to be **signed in as an admin** to open the **Share popup** and generate links/passwords.
+- Know **which surface** you are sharing — the rules differ by page type (see the table below).
+- Decide **who** should be able to view vs. edit. Never send an edit link when you mean a report.
+
+## Step by step
+
+### 1. Open the Share popup
+From an admin list (for example `/admin/events`), use the surface's **Share** action. The Share popup opens with the title matching the surface (e.g. "Share Statistics Page" or "Share Edit Page").
+
+### 2. Read what it gives you
+The popup generates two things for the page:
+
+- **🔗 Shareable URL** — the link to the page. There are **Copy** and **🔎 Visit** buttons.
+- **🔐 Access Password** — a 32-character password (looks like an MD5 hash). There is a **Copy** button.
+
+There is also an optional **Recipient Name or Email** field. It is **for your reference only** — a note to help you remember who you shared with. It does not restrict who can use the link.
+
+### 3. Follow the built-in instructions
+The popup spells out the safe way to share:
+
+1. Share the URL with the intended recipient.
+2. Provide the password **separately** (through a different channel), for security.
+3. They use the password to open the page — and **signed-in admins bypass the prompt** entirely.
+
+### 4. Know which surfaces actually prompt for the password
+This is the crucial rule. The Share popup can generate a password for any page type, but only some surfaces actually **prompt** for it:
+
+| Surface | URL shape | Password-prompted? | Protected by |
+|---|---|---|---|
+| Event report | `/report/{viewSlug}` | **No** | Unguessable UUID slug |
+| Partner report | `/partner-report/{slug}` | **No** | Unguessable slug |
+| Organisation report | `/organization-report/{id}` | **No** | Unguessable id |
+| Filter page | `/filter/{slug}` | **Yes** | Page password |
+| Hashtag page | `/hashtag/{hashtag}` | **Yes** | Page password |
+| Event editor | `/edit/{editSlug}` | **Yes** | Page password |
+| Partner editor | `/partner-edit/{slug}` | **Yes** | Page password |
+| Organisation editor | `/organization-edit/{id}` | **Yes** | Page password |
+
+In plain terms:
+
+- **Event, partner, and organisation reports are NOT password-prompted.** Anyone with the link can view them. Their protection is that the UUID slug in the URL is random and cannot be guessed. Treat the report link itself as the secret.
+- **Filter and hashtag pages ARE password-gated.** These aggregate across many events, so they carry a password prompt on top of the link.
+- **All edit surfaces (`/edit`, `/partner-edit`, `/organization-edit`) are page-password gated.** This is exactly what lets a non-admin edit via a link plus password without an admin account.
+
+### 5. Enter the password (the recipient's view)
+When a recipient opens a gated page, they see the **Access Required** screen: a single password field and an **Access Page** button. On success they are let in. The screen also reminds them that a signed-in admin session bypasses the prompt.
+
+## Managing it
+**How sessions behave.** When a recipient enters a valid page password, messmass remembers it for that page in their browser session, so they are not re-prompted on every reload:
+
+- **Page-password access lasts 24 hours.**
+- **Admin sessions last 7 days.**
+
+After the window, the page prompts again. This is per page and per browser — clearing the browser session or using another device requires re-entry.
+
+**Admins bypass everything.** A signed-in admin session is checked first; if present, the page opens without any prompt on any gated surface. This is why an operator testing a "gated" link while still logged in as admin may never see the password screen — open it in a private window (or while signed out) to experience what the recipient experiences.
+
+**Regenerating vs. reusing.** Opening the Share popup reuses the existing password for a page rather than minting a new one each time, so a link and password you shared earlier keep working. Treat the password like a shared secret and rotate it (via admin tooling) if it leaks.
+
+**The page types at a glance.** messmass recognises a fixed set of page types, and each maps to one URL family and one gating rule:
+
+- `event-report`, `partner-report`, `organization-report` — **open** (UUID-protected reports).
+- `filter`, `hashtag` — **password-gated** aggregate pages.
+- `edit`, `partner-edit`, `organization-edit` — **password-gated** editing surfaces.
+
+When you generate a link, the popup already knows the page type and produces the correct URL family; your job is just to pick the right surface and route the password appropriately.
+
+**Staff dashboards (SSO).** Beyond the shareable surfaces above, there are internal analytics dashboards under **`/dashboard/*`** (for example `/dashboard/partner`, `/dashboard/hashtag`, `/dashboard/filter`). These are **not** page-password surfaces — they require a signed-in admin session, and when single sign-on is configured they require an **SSO** session specifically. The same SSO requirement applies to `/admin/dashboard`. See [Authentication & SSO](guides-tutorial-authentication-sso.md).
+
+## Gotchas & good practice
+- **The report link IS the password.** Because reports are not prompted, forwarding a `/report/...`, `/partner-report/...`, or `/organization-report/...` link gives full view access. Share it only with people who should see the numbers.
+- **Never paste an edit link where you meant a report.** `/edit/...` grants data-entry access. If you want someone to only look, send the `/report/...` link.
+- **Send URL and password on separate channels.** The popup recommends it: one leaked message should not both reveal the link and unlock it.
+- **Test gated links while signed out.** Admins bypass the prompt, so a quick "does the password work?" check must be done in a private/incognito window.
+- **The recipient field is a memo, not a lock.** Filling in a name or email does not tie the link to that person — anyone with the URL (and password, where required) still gets in.
+- **24h means re-prompting.** Field partners returning the next day will be asked for the password again — that is expected, not a failure. Keep the password handy for them.
+- **Dashboards are staff-only.** Do not try to hand out `/dashboard/*` via a page password; those require an admin (and SSO where configured) sign-in.
+
+## How it connects
+- **Reports** are the primary thing you share — see [Reports](guides-tutorial-reports.md) and [Report variants](guides-tutorial-report-variants.md).
+- **Editing via link + password** is how partners self-serve data entry — see [Collecting event data](guides-tutorial-collecting-data.md).
+- **Filter and hashtag pages** are the gated aggregate surfaces — see [Hashtags & filters](guides-tutorial-hashtags-filters.md).
+- **Partner and organisation** report/edit surfaces roll up events — see [Partners](guides-tutorial-partners.md) and [Organisations](guides-tutorial-organisations.md).
+- **Admin and SSO sessions** govern who bypasses prompts and who reaches dashboards — see [Authentication & SSO](guides-tutorial-authentication-sso.md).
+
+## Screenshots
+_Screenshots to be added._
+
+## Related tutorials
+- [Events](guides-tutorial-events.md)
+- [Collecting event data (Clicker & Manual)](guides-tutorial-collecting-data.md)
+- [Reports](guides-tutorial-reports.md)
+- [Hashtags & filters](guides-tutorial-hashtags-filters.md)
+- [Partners](guides-tutorial-partners.md)
+- [Organisations](guides-tutorial-organisations.md)
+- [Authentication & SSO](guides-tutorial-authentication-sso.md)

--- a/docs/guides/guides-tutorial-sport-databases.md
+++ b/docs/guides/guides-tutorial-sport-databases.md
@@ -1,0 +1,184 @@
+# Tutorial: Sport databases
+Status: Active
+Last Updated: 2026-07-20T00:00:00.000Z
+Canonical: Yes
+Owner: Documentation
+
+> Audience: Operators and technical implementers · Prerequisites: Admin sign-in, at least one partner created · Related: [Partners](guides-tutorial-partners.md), [Events](guides-tutorial-events.md), [Bitly integration](guides-tutorial-bitly.md)
+
+## What it is & why it matters
+
+messmass can enrich your **partners** (clubs, teams, venues) with authoritative sports data pulled from three external providers, and it can use their **fixtures** to pre-create events for you. All three are inbound only — messmass reads from them and writes the result onto your own records; it never pushes data back out.
+
+Enrichment fills in the things that make a partner and its reports look complete:
+
+- **Hashtags** (country, league, sport) generated from official metadata.
+- **Crests / logos** hosted on your own image store.
+- **Venue capacity** and city.
+- **League / competition** membership.
+
+Fixture data goes one step further: a scheduled match between two teams can become a draft event in messmass, so operators do not have to key in "Team A x Team B" by hand.
+
+The three providers overlap deliberately. Pick based on the sport and what you need:
+
+| Provider | Library | Best for |
+|----------|---------|----------|
+| **Football-Data.org** | `lib/footballDataApi.ts` | Top-flight European football: official team IDs, competitions, crests, and fixture-driven event creation |
+| **API-Football / API-Sports** | `lib/api-football.ts` | Multi-sport coverage (soccer, basketball, handball, hockey, volleyball) and venue capacity, via batch enrichment |
+| **TheSportsDB** | `lib/sportsDbApi.ts` | The broadest catalogue and interactive team/venue lookup straight from the partner UI; a good fallback and for one-off searches |
+
+### Which one should I use?
+
+- **You run a Premier League / La Liga / Serie A / Bundesliga / Ligue 1 club and want events created from the schedule.** Use **Football-Data.org**. It gives you official team IDs and competitions, and its fixtures can drive draft event and draft partner creation.
+- **Your partner plays basketball, handball, ice hockey or volleyball, or you want venue capacity across many sports.** Use **API-Football / API-Sports**. It searches five sports and stores venue capacity, city and logo.
+- **You just need to find a team quickly, grab a crest, or cover a club the other two miss.** Use **TheSportsDB**. Its search and lookup are wired into the partner UI for interactive use, and it has the widest catalogue.
+
+Nothing stops you using more than one: each provider writes into a different part of the partner record, so they coexist. A common pattern is Football-Data.org for fixtures and hashtags on major football clubs, with TheSportsDB filling gaps for smaller clubs.
+
+## Before you start
+
+1. **Sign in as an admin.** Every sport-data route is admin-only.
+2. **Provide the API keys you intend to use** as environment variables (names only — never paste key values):
+   - Football-Data.org: `FOOTBALL_DATA_API_TOKEN` (optional: `FOOTBALL_DATA_BASE_URL`).
+   - API-Football / API-Sports: `API_FOOTBALL_KEY`.
+   - TheSportsDB: `SPORTSDB_API_KEY` (optional: `SPORTSDB_BASE_URL`; a limited free-tier key is used if none is set).
+3. **Create the partners you want to enrich** first. See [Partners](guides-tutorial-partners.md).
+4. **Mind the free-tier rate limits.** Each client throttles itself, but the limits are real. Enrichment therefore runs in small, spaced batches.
+
+| Provider | Free-tier limit | How the client copes |
+|----------|-----------------|----------------------|
+| Football-Data.org | ~10 requests / minute | Spaces requests ~6.5s apart; retries once on 429 |
+| TheSportsDB | 3 requests / minute | Queues and waits for the window to reset; caches results |
+| API-Football | ~100 requests / day per sport | 24-hour cooldown between enrichment runs; 5 partners per run |
+
+## Step by step
+
+### A. Football-Data.org — link a partner and sync fixtures
+
+**Link a partner to an official team.** Send the team's Football-Data ID to link it:
+
+- `POST /api/partners/link-football-data` with body `{ partnerId, footballDataTeamId }`.
+
+This fetches the team from Football-Data.org, generates country/league/sport hashtags and merges them into the partner, uploads the crest to your image store and stores it as the partner's `logoUrl` (if one is not set), and records a `footballData` block (team id, name, short name, three-letter abbreviation, crest, competitions, last-synced timestamp) on the partner.
+
+**Sync fixtures.** Refresh the fixture cache with:
+
+- `POST /api/football-data/sync` with an optional body `{ competitionIds, status, dateFrom, dateTo }`. If you send no `competitionIds`, it syncs a default set of major competitions (Premier League, La Liga, Serie A, Bundesliga, Ligue 1, Brasileirão, Champions League). It imports fixtures into a local cache, then matches them to partners by team ID.
+
+Browse the cached fixtures without hitting the external API via `GET /api/football-data/fixtures`.
+
+### B. API-Football / API-Sports — enrich partners across sports
+
+Trigger a batch enrichment run:
+
+- `POST /api/api-football/enrich-partners`.
+
+Each run takes the next **5** partners that have not yet been enriched, searches each supported sport (soccer, basketball, handball, hockey, volleyball) for a matching team, and on the first match stores an `enrichedData.apiFootball` block containing the team ID, sport, country, founded year, logo, and venue details including **capacity**, address and city. To respect the daily quota there is a **24-hour cooldown**: the run can only fire once per day.
+
+Check whether the button should be enabled with:
+
+- `GET /api/api-football/enrich-partners` — returns whether a run is currently allowed, how many partners remain unenriched, and when the next run becomes available.
+
+### C. TheSportsDB — search and look up from the partner UI
+
+TheSportsDB powers interactive lookups when you are working on a partner:
+
+- **Search** a team by name: `GET /api/sports-db/search?type=team&query=<name>`.
+- **Look up** full details (including stadium capacity) once you have an ID: `GET /api/sports-db/lookup`.
+- **Sync** upcoming fixtures for all partners that have a TheSportsDB team ID, then match them: `POST /api/sports-db/sync`.
+- **Browse** the cached fixtures: `GET /api/sports-db/fixtures` (filter by `partnerId`, `teamId`, date range or status).
+- **Create a draft event** in one click from a cached fixture: `POST /api/sports-db/fixtures/draft`.
+
+### Endpoint reference
+
+| Provider | Purpose | Endpoint |
+|----------|---------|----------|
+| Football-Data.org | Link a partner to a team | `POST /api/partners/link-football-data` |
+| Football-Data.org | Sync fixtures for competitions | `POST /api/football-data/sync` |
+| Football-Data.org | Read cached fixtures | `GET /api/football-data/fixtures` |
+| API-Football | Enrich the next batch of partners | `POST /api/api-football/enrich-partners` |
+| API-Football | Check enrichment status / cooldown | `GET /api/api-football/enrich-partners` |
+| TheSportsDB | Search team by name | `GET /api/sports-db/search?type=team&query=…` |
+| TheSportsDB | Look up team / venue / league by ID | `GET /api/sports-db/lookup` |
+| TheSportsDB | Sync + match fixtures for all partners | `POST /api/sports-db/sync` |
+| TheSportsDB | Read cached fixtures | `GET /api/sports-db/fixtures` |
+| TheSportsDB | One-click draft event from a fixture | `POST /api/sports-db/fixtures/draft` |
+
+### Worked example: enrich a basketball club
+
+1. Create the partner (for example "KK Partizan") — see [Partners](guides-tutorial-partners.md).
+2. Check the enrichment status with `GET /api/api-football/enrich-partners`; if a run is allowed and the partner is unenriched, it will be picked up.
+3. Trigger `POST /api/api-football/enrich-partners`. The run searches soccer first, then basketball, and on the basketball match stores `enrichedData.apiFootball` with the arena's capacity and city.
+4. Open the partner and confirm the matched team is correct before relying on the capacity in a report.
+5. A day later (after the cooldown), run enrichment again to pick up the next five partners.
+
+## Managing it
+
+- **Fixtures can create events for you.** Cached fixtures are the raw material for automatic event creation. For Football-Data, the importer can create a draft partner for an unknown opponent and a draft event for a fixture whose home team already exists as a partner; a bulk pass can do this across the whole fixture cache. TheSportsDB offers the same idea through its one-click "draft" endpoint.
+- **Two feature flags govern automatic creation** (Football-Data path), set as environment variables:
+  - `FOOTBALL_DATA_AUTO_CREATE_PROJECTS` — auto-create draft events from fixtures (default on).
+  - `FOOTBALL_DATA_AUTO_CREATE_PARTNERS` — auto-create draft partners for opponents not yet in your database (default on).
+  - `FOOTBALL_DATA_SYNC_INTERVAL_HOURS` tunes how often scheduled syncs run (default 6).
+  Turn a flag off (set it to `false`) if you would rather review and create events manually.
+- **Enrichment is additive.** Linking or enriching a partner merges new hashtags with existing ones and only fills a logo if one is not already present — it does not overwrite your curated data wholesale.
+- **Re-run to refresh.** Because each provider stamps a last-synced time, you can re-link or re-enrich later to pull fresher metadata.
+
+### What lands on the partner record
+
+Each provider writes to a distinct field so they never collide:
+
+| Provider | Partner field | Notable contents |
+|----------|---------------|------------------|
+| Football-Data.org | `footballData` | Official team ID, name, abbreviation, crest, competitions, last-synced time; plus merged hashtags and a `logoUrl` |
+| API-Football | `enrichedData.apiFootball` | Team ID, sport, country, founded year, logo, and venue name/city/capacity |
+| TheSportsDB | Team/venue lookups | Stadium capacity, crest and league metadata surfaced through search and lookup |
+
+### Environment variables at a glance
+
+| Variable | Provider | Purpose |
+|----------|----------|---------|
+| `FOOTBALL_DATA_API_TOKEN` | Football-Data.org | API access token (required to use it) |
+| `FOOTBALL_DATA_BASE_URL` | Football-Data.org | Override the API base URL (optional) |
+| `FOOTBALL_DATA_SYNC_INTERVAL_HOURS` | Football-Data.org | Scheduled sync cadence (default 6) |
+| `FOOTBALL_DATA_AUTO_CREATE_PROJECTS` | Football-Data.org | Auto-create draft events from fixtures (default on) |
+| `FOOTBALL_DATA_AUTO_CREATE_PARTNERS` | Football-Data.org | Auto-create draft partners for unknown opponents (default on) |
+| `API_FOOTBALL_KEY` | API-Football / API-Sports | API access key (required to use it) |
+| `SPORTSDB_API_KEY` | TheSportsDB | API key (a limited free key is used if unset) |
+| `SPORTSDB_BASE_URL` | TheSportsDB | Override the API base URL (optional) |
+
+## Gotchas & good practice
+
+- **Choose the right provider for the sport.** Football-Data.org is football-only and strongest for major European leagues; reach for API-Football when the partner plays basketball, handball, hockey or volleyball, or when you want venue capacity across sports; use TheSportsDB for interactive search and the widest catalogue.
+- **Respect the quotas.** The 24-hour cooldown on API-Football enrichment and the 3-per-minute TheSportsDB limit are there for a reason. Batch runs are intentionally small; do not try to force a full backfill in one sitting.
+- **Fuzzy name matching can mis-match.** API-Football searches by cleaned partner name and takes the first hit. After an enrichment run, spot-check that the matched team is actually the right club before trusting its crest or capacity.
+- **Draft events are drafts.** Auto-created events are pre-populated for planning. Review names, dates and hashtags before you collect data against them or publish a report.
+- **Keys are environment-only.** `FOOTBALL_DATA_API_TOKEN`, `API_FOOTBALL_KEY` and `SPORTSDB_API_KEY` must live in the environment, never in the UI or a spreadsheet.
+
+> Note: Coverage differs by plan. A free Football-Data.org plan exposes a limited set of competitions; if a partner's league is not covered, its competitions list may come back empty even though the team links successfully.
+
+### Quick troubleshooting
+
+| Symptom | Likely cause | What to do |
+|---------|--------------|------------|
+| "not configured" error on a sync/enrich call | The relevant API key env var is unset | Set `FOOTBALL_DATA_API_TOKEN`, `API_FOOTBALL_KEY` or `SPORTSDB_API_KEY` as appropriate |
+| Enrichment says "already run today" | 24-hour API-Football cooldown | Wait for the reported next-available time, then re-run |
+| A partner got the wrong team's crest/capacity | Fuzzy name match took the wrong hit | Correct it on the partner; re-link with an explicit team ID where possible |
+| Fixtures did not appear | Competition not in your synced set or plan | Pass explicit `competitionIds` to the football-data sync, or check plan coverage |
+| Search returns nothing on TheSportsDB | Rate limit or spelling | Wait for the 3/min window; try the club's common name |
+
+## How it connects
+
+- **Partners** are the destination for all enrichment — the hashtags, crest, capacity and league all land on the partner record. See [Partners](guides-tutorial-partners.md) and the technical [partners system guide](../features/features-partners-system-guide.md).
+- **Events** are what fixtures become. The Sports Match Builder and the draft-creation endpoints both produce events from two partners. See [Events](guides-tutorial-events.md).
+- **Bitly and reports** benefit indirectly: richer partner metadata (crest, league, hashtags) flows into the events created from those partners and into their reports. See [Bitly integration](guides-tutorial-bitly.md) and [Reports](guides-tutorial-reports.md).
+
+## Screenshots
+_Screenshots to be added._
+
+## Related tutorials
+
+- [Partners](guides-tutorial-partners.md)
+- [Events](guides-tutorial-events.md)
+- [Bitly integration](guides-tutorial-bitly.md)
+- [Google Sheets sync](guides-tutorial-google-sheets.md)
+- [Authentication, roles & SSO](guides-tutorial-authentication-sso.md)

--- a/docs/guides/guides-tutorial-variables-kyc.md
+++ b/docs/guides/guides-tutorial-variables-kyc.md
@@ -1,0 +1,114 @@
+# Tutorial: Variables (KYC)
+Status: Active
+Last Updated: 2026-07-20T00:00:00.000Z
+Canonical: Yes
+Owner: Documentation
+
+> Audience: Internal operators & admins (system builders) · Prerequisites: Admin sign-in · Related: [Clicker sets](guides-tutorial-clicker-sets.md) · [Charts & formulas](guides-tutorial-charts-formulas.md) · [Collecting data](guides-tutorial-collecting-data.md)
+
+## What it is & why it matters
+The **KYC Variables** page at `/admin/kyc` is the single catalog of every data field messmass knows about. If a number, a percentage, a currency amount, a date, or a block of text can appear on a counter or in a chart, it exists here first.
+
+Why this matters: a variable's **name** is used unchanged everywhere. The same `female` that you define here is the key stored on each event's `stats{}`, the counter that shows up in the clicker, and the token `[female]` you type into a chart formula. There is **no translation layer** — the database field name, the clicker counter, and the formula token are all the same string. Get the catalog right and everything downstream lines up; misname something here and every formula that brackets it breaks.
+
+Think of KYC as the dictionary. [Clicker sets](guides-tutorial-clicker-sets.md) decides which words appear on the data-entry screen and in what order; [Charts & formulas](guides-tutorial-charts-formulas.md) decides how those words are combined into visualisations.
+
+## Before you start
+- Sign in as an admin. The page lives at `/admin/kyc` and is titled **🔐 KYC Variables** ("Catalog of all variables (manual, system, derived) powering analytics and clicker").
+- Understand the naming rule before you create anything: variable names must be **camelCase** — start with a letter, letters and digits only, no spaces, no `stats.` prefix (e.g. `fanCount`, `vipGuests`, `female`). The page enforces the pattern `^[a-zA-Z][a-zA-Z0-9]*$`.
+- Decide up front whether a new variable should be countable in the clicker, editable by hand, or both — you set those flags at creation.
+
+## Step by step
+
+### 1. Read the catalog
+Each variable is listed as a card showing:
+- the **Label** (human-readable heading) and the **name** shown as a `[name]` code chip,
+- a **TYPE** badge (COUNT, NUMERIC, CURRENCY, PERCENTAGE, BOOLEAN, DATE, TEXT, …),
+- a **source** badge — one of `manual`, `system`, `derived`, or `text` (computed from the variable, not stored),
+- a green **clicker** badge if it is visible in the clicker, a yellow **manual** badge if it is editable in manual mode,
+- a **Legacy stats.** badge on built-in schema fields (variables flagged `isSystem`).
+
+Use the search box in the hero to match on name, label, category, or description.
+
+### 2. Filter to find things
+The green filter card gives you four narrowing tools:
+- **Source** — check/uncheck `manual`, `system`, `derived`, `text`.
+- **Flags** — show only variables that are visible in clicker and/or editable in manual.
+- **Legacy (stats. schema)** — "Show only legacy stats. fields" narrows to system variables. This is warn-only; it changes nothing about behaviour.
+- **Tags (Categories)** — click category chips to show only those categories; **Clear** resets.
+
+### 3. Create a variable
+Click **New Variable** (the ➕ button in the hero). In the **➕ New Variable** modal:
+1. **Name (camelCase)** — e.g. `vipGuests`. No `stats.` prefix.
+2. **Label** — e.g. `VIP Guests`.
+3. **Type** — choose from:
+   - `count` — whole numbers (0, 1, 2…)
+   - `numeric` — decimal numbers
+   - `currency` — money values (€/$/£)
+   - `percentage` — 0–100%
+   - `boolean` — true/false checkbox
+   - `date` — date picker
+   - `text` — single-line text (title, name)
+   - `textarea` — multi-line text content (e.g. a markdown table)
+   - `texthyper` — URL, email, phone, social handle
+   - `textmedia` — image upload
+4. **Category** — a grouping tag such as `Event` or `Demographics`.
+5. **Description (optional)** — what this tracks.
+6. **Visible in Clicker** / **Editable in Manual** — the two flags that decide where the field appears during data entry.
+
+Name, Label, and Category are required. Click **Create**.
+
+> Note: The create modal also renders type-specific helper fields (max length, subtype, currency symbol, min/max, max file size). Treat these as guidance for the value you enter; the always-persisted fields are name, label, type, category, description, and the two flags.
+
+### 4. Edit a variable
+Click **Edit** on a card. You can always change the **Label**, **Category**, and the **Visible in Clicker** / **Editable in Manual** flags. The **Type** is shown read-only. The **Name** is editable only for custom variables — built-in (registry) variables show "Built-in variables cannot be renamed here to avoid breaking stored data."
+
+### 5. Delete a variable
+Custom variables show a **Delete** button (with a confirm prompt). **System variables have no Delete button** — they map to stored schema fields and are protected. Deleting also force-refreshes the shared cache so the removal shows up immediately.
+
+### 6. Export the catalog
+The hero has **Export CSV** and **Export JSON** buttons. Both export the **currently filtered** list, timestamped. CSV columns are: `name, label, type, source, category, visibleInClicker, editableInManual, derived, description`. Use these for audits or to hand the catalog to a colleague.
+
+### 7. A worked example — one variable, two destinations
+Suppose you want to count VIP guests at an activation and show them on the report:
+1. **Create** a variable here: name `vipGuests`, label `VIP Guests`, type `count`, category `Event`, with **Visible in Clicker** and **Editable in Manual** both ticked.
+2. In [Clicker sets](guides-tutorial-clicker-sets.md), add `vipGuests` to a variable group so it appears as a counter in the editor.
+3. Operators tap the counter during the event; the value lands on the event's `stats.vipGuests`.
+4. In [Charts & formulas](guides-tutorial-charts-formulas.md), reference it as `[vipGuests]` — for example a KPI chart with formula `[vipGuests]`, or a ratio like `[vipGuests] / [eventAttendees] * 100` with a `%` suffix.
+
+The exact same string `vipGuests` did all four jobs. That single-name principle is the whole point of the catalog.
+
+## Managing it
+**Source is computed, not stored.** The `manual / system / derived / text` badge is derived on the fly: a variable with a formula reads `derived`; a `text` type reads `text`; a variable whose category starts with `bitly` reads `system`; everything else reads `manual`. So changing a variable's category (e.g. into a Bitly grouping) can change how it is classified in the filters.
+
+**System vs custom.** Variables flagged `isSystem` (shown with the **Legacy stats.** badge and a `system` source) are engine-managed schema fields — they cannot be deleted here and their name cannot be changed. Custom variables you create can be freely renamed and deleted.
+
+**Derived variables.** A variable can carry a **formula** and be marked `derived`; its description then shows the formula and its source badge reads `derived`. Derived variables are computed rather than entered, so they typically are not clicker counters.
+
+**The cache.** The catalog is cached for performance (about five minutes). Every create, edit, and delete triggers a cache invalidation so the change is visible right away — but if you edited the database directly (don't), other surfaces might lag. From [Clicker sets](guides-tutorial-clicker-sets.md) and [Charts & formulas](guides-tutorial-charts-formulas.md), the **Refresh Variables** button forces the same invalidation so a newly created variable appears without waiting.
+
+**Where a variable shows up next.** Creating a variable here does not automatically put it anywhere. To make it a clicker counter, add it to a variable group in a [clicker set](guides-tutorial-clicker-sets.md) (only variables flagged **Visible in Clicker** can be added). To put it on a report, reference `[name]` in a [chart formula](guides-tutorial-charts-formulas.md).
+
+## Gotchas & good practice
+- **Name = key = token.** The name you type is the exact stats key and the exact formula token. `[female]` in a formula only works because the variable is named `female`. There is no aliasing of the underlying key.
+- **camelCase only.** No spaces, no `stats.` prefix, no dashes. The page rejects anything else with "Name must be camelCase (e.g., fanCount, vipGuests, female)".
+- **Don't rename built-ins.** System variables are locked precisely because a rename would orphan stored data and break every formula that references them.
+- **Flags are not the same as visibility everywhere.** "Visible in Clicker" only makes a variable *eligible* to be placed in a clicker group — it still has to be added to a group in a clicker set to actually appear.
+- **A new variable that "won't show up"** is almost always the cache or a missing group assignment, not a bug. Click **Refresh Variables** on the Clicker or Charts page, then confirm the variable is in a group.
+- **Export before bulk changes.** Grab a CSV/JSON snapshot before a cleanup pass so you can diff what changed.
+
+## How it connects
+- **Data entry:** which variables become counters, and their order, is set in [Clicker sets & variable groups](guides-tutorial-clicker-sets.md); the entry experience itself is [Collecting data](guides-tutorial-collecting-data.md).
+- **Reporting:** variable names become `[token]` references in [Charts & formulas](guides-tutorial-charts-formulas.md).
+- **Text & image variables:** longer-form content variables are managed alongside the [Content Library](guides-tutorial-content-library.md).
+- **Deeper reference:** the operational [Variable Management Guide](guides-variable-management.md) covers the formula engine and validation lifecycle in detail.
+
+## Screenshots
+_Screenshots to be added._
+
+## Related tutorials
+- [Clicker sets & variable groups](guides-tutorial-clicker-sets.md)
+- [Charts & formulas](guides-tutorial-charts-formulas.md)
+- [Content Library (images & text)](guides-tutorial-content-library.md)
+- [Collecting event data](guides-tutorial-collecting-data.md)
+- [Variable Management Guide](guides-variable-management.md)

--- a/docs/guides/guides-tutorials-index.md
+++ b/docs/guides/guides-tutorials-index.md
@@ -1,0 +1,68 @@
+# messmass Tutorials — Learning Path
+Status: Active
+Last Updated: 2026-07-20T00:00:00.000Z
+Canonical: Yes
+Owner: Documentation
+
+> Audience: operators, implementation partners, and technical admins · Prerequisites: an admin login (see [Authentication, roles & SSO](guides-tutorial-authentication-sso.md)) · Related: [Getting Started](guides-tutorial-getting-started.md)
+
+## What this is
+
+A task-oriented set of tutorials for **using** messmass — creating and managing the core objects, and connecting the platform to the other apps it works with. Each tutorial explains *what a thing is*, *why it exists*, and *how to create and manage it*, with the exact admin routes and button labels.
+
+If you read nothing else, read **[Getting Started](guides-tutorial-getting-started.md)** first — it sets up the mental model everything below builds on.
+
+## The mental model
+
+```
+Organisation  →  Partner  →  Event (project)  →  Report
+     │              │              │                 │
+  groups        team / club     one match /      what the audience
+  partners      / sponsor       activity         actually sees
+```
+
+Data is captured against an **event** (via the Clicker/Manual editor, Google Sheets, or Fanmass), then presented through a **report** (a template of blocks and charts, themed by a style, optionally sliced into time-based variants), and shared with a link.
+
+## Learning path
+
+### Phase 1 — Core objects (start here)
+1. [Getting Started with messmass](guides-tutorial-getting-started.md) — the big picture, roles, and logging in.
+2. [Organisations](guides-tutorial-organisations.md) — the top-level grouping of partners.
+3. [Partners](guides-tutorial-partners.md) — teams, clubs, and sponsors that own events.
+4. [Events](guides-tutorial-events.md) — the individual matches/activities you report on.
+5. [Collecting event data](guides-tutorial-collecting-data.md) — the Clicker & Manual editor.
+6. [Building reports](guides-tutorial-reports.md) — templates, data blocks, and charts.
+7. [Report themes & styles](guides-tutorial-report-themes.md) — colours, fonts, and how a theme is chosen.
+8. [Report variants](guides-tutorial-report-variants.md) — time-scoped, publishable report versions.
+9. [Sharing reports & access control](guides-tutorial-sharing-access.md) — links, page passwords, and who can see what.
+
+### Phase 2 — Building blocks (power users)
+10. [Variables (KYC)](guides-tutorial-variables-kyc.md) — the single source of truth for every stat.
+11. [Clicker sets & variable groups](guides-tutorial-clicker-sets.md) — how the data-entry counters are laid out.
+12. [Charts & formulas](guides-tutorial-charts-formulas.md) — chart types and the `[variable]` formula language.
+13. [Content Library (images & text)](guides-tutorial-content-library.md) — reusable media/text assets for reports.
+14. [Hashtags, categories & filters](guides-tutorial-hashtags-filters.md) — tagging and cross-event filter reports.
+
+### Phase 3 — Integrations & connections
+15. [Camera app integration](guides-tutorial-camera-app.md) — provisioning orgs/partners/events into the selfie-capture app.
+16. [Fanmass integration](guides-tutorial-fanmass.md) — image-intelligence analytics and the mapping API.
+17. [Bitly integration](guides-tutorial-bitly.md) — short-link click analytics attributed to events/partners.
+18. [Sport databases](guides-tutorial-sport-databases.md) — Football-Data.org, API-Football, and TheSportsDB enrichment.
+19. [Google Sheets sync](guides-tutorial-google-sheets.md) — managing a partner's events from a spreadsheet.
+20. [Authentication, roles & SSO](guides-tutorial-authentication-sso.md) — sign-in, roles, SSO, and API keys.
+
+## Quick start by role
+
+- **New operator** → Getting Started → Organisations → Partners → Events → Collecting data → Building reports → Sharing.
+- **Report designer** → Variables → Charts → Content Library → Building reports → Themes → Variants.
+- **Integrations / setup** → Authentication & SSO → Camera → Fanmass → Bitly → Sport databases → Google Sheets.
+
+## Notes on scope
+
+- These tutorials describe the **current** admin experience. A few legacy internals are called out where they might confuse (for example the legacy `reports` collection versus the current report templates, and the legacy page-style system versus the current report styles).
+- Screenshots are being added in a follow-up pass; each tutorial has a **Screenshots** section reserved for them.
+
+## Related
+
+- [Admin end-user guide](../admin/admin-end-user-guide.md) — the canonical operator reference these tutorials expand on.
+- [Documentation index](../index.md) — the full documentation map.

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,6 +14,14 @@ Owner: Documentation
 - [coding-standards.md](coding-standards.md) — Code style, naming conventions, and documentation expectations.
 - [documentation-governance.md](documentation-governance.md) — Rules for canonical docs, deprecation, and required metadata.
 
+## Tutorials (Learning Path)
+Task-oriented, end-user tutorials for creating and managing the core objects and connecting messmass to the apps it works with. Start with the index, which orders everything into a learning path.
+
+- [guides-tutorials-index.md](guides/guides-tutorials-index.md) — **Start here.** The tutorials hub and ordered learning path.
+- Core objects: [Getting Started](guides/guides-tutorial-getting-started.md) · [Organisations](guides/guides-tutorial-organisations.md) · [Partners](guides/guides-tutorial-partners.md) · [Events](guides/guides-tutorial-events.md) · [Collecting event data](guides/guides-tutorial-collecting-data.md) · [Building reports](guides/guides-tutorial-reports.md) · [Report themes & styles](guides/guides-tutorial-report-themes.md) · [Report variants](guides/guides-tutorial-report-variants.md) · [Sharing & access](guides/guides-tutorial-sharing-access.md)
+- Building blocks: [Variables (KYC)](guides/guides-tutorial-variables-kyc.md) · [Clicker sets](guides/guides-tutorial-clicker-sets.md) · [Charts & formulas](guides/guides-tutorial-charts-formulas.md) · [Content Library](guides/guides-tutorial-content-library.md) · [Hashtags & filters](guides/guides-tutorial-hashtags-filters.md)
+- Integrations: [Camera app](guides/guides-tutorial-camera-app.md) · [Fanmass](guides/guides-tutorial-fanmass.md) · [Bitly](guides/guides-tutorial-bitly.md) · [Sport databases](guides/guides-tutorial-sport-databases.md) · [Google Sheets](guides/guides-tutorial-google-sheets.md) · [Authentication & SSO](guides/guides-tutorial-authentication-sso.md)
+
 ## Operations & Delivery
 - [operations-action-plan.md](operations/operations-action-plan.md) — Tactical queue for ops, sprint goals, and blockers.
 - [operations-delivery-focus.md](operations/operations-delivery-focus.md) — Top 5 value/priority board issues and recommended next delivery step.


### PR DESCRIPTION
A plain fire-and-forget provisioning call is killed by the Vercel serverless runtime once the response returns, so messmass→camera provisioning never ran in production. Wrapping it in `next/server` `after()` runs it after the response and keeps the function alive until it completes. **Verified in production**: creating an event on messmass.com now auto-provisions the camera event under its partner within ~15s. type-check passes; Vercel prod build succeeded. 🤖 Generated with [Claude Code](https://claude.com/claude-code)