### PR TITLE
Send email via camera's shared service instead of a direct Resend integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -45,14 +45,15 @@ FOOTBALL_DATA_SYNC_INTERVAL_HOURS=6
 FOOTBALL_DATA_AUTO_CREATE_PROJECTS=true
 FOOTBALL_DATA_AUTO_CREATE_PARTNERS=true
 
-# Resend email (server-only) — transactional email (admin password regeneration, config self-test)
-# WHAT: Required for lib/emailNotifications.ts to send. Standardized on Resend
-#       (SSO_EMAIL_UNIFICATION_PLAN.md Phase 2) — same provider camera already
-#       uses in production, instead of messmass's previous unconfigured SMTP path.
-# Get your key from: https://resend.com/api-keys
-RESEND_API_KEY=
-# Verified sending identity in Resend, e.g. "messmass" <notifications@messmass.com>
-EMAIL_FROM=
+# Email (transactional — admin password regeneration, config self-test)
+# WHAT: lib/emailNotifications.ts sends via camera's shared internal email
+#       service (POST /api/internal/email/send), not a direct Resend
+#       integration — messmass has no Resend account/key of its own.
+# WHY: Camera is the one app in the stack with a verified Resend sending
+#      domain; this avoids every app duplicating that integration.
+# No new vars needed here — reuses CAMERA_BASE_URL and
+# CAMERA_MESSMASS_INTERNAL_SECRET below (the same credentials already used
+# for messmass -> camera provisioning).
 
 # Cron authorization (server-only)
 # WHAT: Shared secret required by scheduled endpoints (e.g. /api/cron/google-sheets-sync).
@@ -81,6 +82,8 @@ JWT_SECRET=
 
 # --- messmass -> camera provisioning (messmass is master for orgs/partners/events) ---
 # When set, creating an event auto-provisions the mirror event in camera.
+# Also doubles as the auth for camera's shared email service (lib/emailNotifications.ts)
+# — same secret, same trust boundary, not a second credential to manage.
 CAMERA_BASE_URL=http://localhost:3000
 CAMERA_MESSMASS_INTERNAL_SECRET=
 

--- a/lib/emailNotifications.ts
+++ b/lib/emailNotifications.ts
@@ -2,94 +2,101 @@
 // WHAT: Email transport utility for {messmass}
 // WHY: Send the transactional emails the app actually uses (admin password
 //      regeneration, and an email config self-test).
-// HOW: Resend HTTP API — matches camera (lib/email/submission-notification.ts),
-//      standardizing the two apps on one email provider instead of messmass's
-//      previous SMTP-via-nodemailer path. See SSO_EMAIL_UNIFICATION_PLAN.md
-//      Phase 2. SMTP has real serverless drawbacks Resend's HTTP API avoids
-//      (a raw SMTP connection per cold Vercel invocation vs. one POST), and
-//      messmass's SMTP_* vars were never actually configured in production —
-//      this closes that gap rather than just relocating it.
+// HOW: Calls camera's shared internal email service
+//      (POST /api/internal/messmass/email/send is NOT a route -- the actual
+//      path is POST /api/internal/email/send on camera) instead of talking to
+//      Resend directly. Camera is the one app in the SEYU stack with a
+//      working Resend integration and verified sending domain; this avoids
+//      messmass keeping its own separate Resend account/dependency/error
+//      handling, duplicating logic camera already has. Auth reuses
+//      config.cameraProvisionToken -- the SAME shared secret already used for
+//      messmass -> camera provisioning (lib/cameraClient.ts), not a new one.
+//      See SSO_EMAIL_UNIFICATION_PLAN.md.
 //
-// Configuration: RESEND_API_KEY (server-only), EMAIL_FROM (e.g.
-// '"messmass" <notifications@messmass.com>' — verified sending domain in
-// Resend). SMTP_* vars are no longer read; keep them in .env.example only as
-// a historical note if still wired to any external doc, not as live config.
-//
-// NOTE (2026-07-05 audit cleanup, still true): four functions that had ZERO
-// callers were removed — sendSyncSuccessEmail, sendSyncErrorEmail,
-// sendDailySyncSummaryEmail, sendContactFormEmail. The Google-Sheets sync
-// writes status to the partner doc (it never emailed), and the contact route
-// persists via createContactInquiry.
+// If CAMERA_BASE_URL / CAMERA_MESSMASS_INTERNAL_SECRET aren't configured,
+// both functions return false without throwing (same "not configured, skip
+// gracefully" contract the Resend-direct version had).
 
-import { Resend } from 'resend';
+import config from './config';
 
-function getApiKey(): string {
-  return (process.env.RESEND_API_KEY || '').trim();
+function cameraBase(): string {
+  return (config.cameraBaseUrl || '').replace(/\/$/, '');
 }
 
-function getFromAddress(): string {
-  return (process.env.EMAIL_FROM || process.env.SMTP_FROM || '').trim();
+function cameraToken(): string {
+  return config.cameraProvisionToken || '';
 }
 
-function summarizeResendError(error: unknown): string {
-  if (error && typeof error === 'object') {
-    const e = error as Record<string, unknown>;
-    const parts: string[] = [];
-    if (typeof e.message === 'string' && e.message.trim()) parts.push(e.message.trim());
-    if (typeof e.name === 'string' && e.name.trim()) parts.push(`[${e.name.trim()}]`);
-    if (parts.length) return parts.join(' ');
+function emailServiceConfigured(): boolean {
+  return Boolean(config.cameraBaseUrl && config.cameraProvisionToken);
+}
+
+async function sendViaCameraEmailService(params: {
+  to: string;
+  subject: string;
+  html: string;
+}): Promise<{ sent: boolean; error?: string }> {
+  if (!emailServiceConfigured()) {
+    console.error('Email send skipped: CAMERA_BASE_URL / CAMERA_MESSMASS_INTERNAL_SECRET not configured');
+    return { sent: false, error: 'camera_email_service_not_configured' };
   }
-  return error instanceof Error ? error.message : String(error);
+
+  try {
+    const res = await fetch(`${cameraBase()}/api/internal/email/send`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'x-messmass-secret': cameraToken(),
+        authorization: `Bearer ${cameraToken()}`,
+      },
+      body: JSON.stringify({ to: params.to, subject: params.subject, html: params.html, fromName: 'messmass' }),
+    });
+
+    const json = (await res.json().catch(() => ({}))) as {
+      success?: boolean;
+      data?: { sent?: boolean; error?: string; messageId?: string | null };
+      error?: { message?: string };
+    };
+
+    if (!res.ok) {
+      const message = json?.error?.message || `camera responded ${res.status}`;
+      console.error('Email send failed (camera service error):', message);
+      return { sent: false, error: message };
+    }
+
+    if (!json?.data?.sent) {
+      console.error('Email send failed (Resend rejected via camera):', json?.data?.error);
+      return { sent: false, error: json?.data?.error || 'unknown_error' };
+    }
+
+    return { sent: true };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error('Email send failed (network error calling camera):', message);
+    return { sent: false, error: message };
+  }
 }
 
 /**
  * WHAT: Test email configuration
- * WHY: Verify Resend credentials + sender identity work before relying on them
+ * WHY: Verify the camera email service (and Resend behind it) works before relying on it
  */
 export async function testEmailConfig(recipientEmail: string): Promise<boolean> {
-  const apiKey = getApiKey();
-  const from = getFromAddress();
+  const result = await sendViaCameraEmailService({
+    to: recipientEmail,
+    subject: '✅ {messmass} Email Configuration Test',
+    html: `
+      <h2>Email Configuration Test</h2>
+      <p>This is a test email from {messmass} to verify the email service configuration.</p>
+      <p>If you received this email, your email notifications are working correctly!</p>
+      <p><small>Sent at: ${new Date().toISOString()}</small></p>
+    `,
+  });
 
-  if (!apiKey) {
-    console.error('Email configuration test failed: RESEND_API_KEY is not set');
-    return false;
-  }
-  if (!from) {
-    console.error('Email configuration test failed: EMAIL_FROM is not set');
-    return false;
-  }
-
-  try {
-    const resend = new Resend(apiKey);
-    const response = await resend.emails.send({
-      from,
-      to: recipientEmail,
-      subject: '✅ {messmass} Email Configuration Test',
-      html: `
-        <h2>Email Configuration Test</h2>
-        <p>This is a test email from {messmass} to verify the Resend configuration.</p>
-        <p>If you received this email, your email notifications are working correctly!</p>
-        <hr>
-        <p><strong>Configuration:</strong></p>
-        <ul>
-          <li>Provider: Resend</li>
-          <li>From: ${from}</li>
-        </ul>
-        <p><small>Sent at: ${new Date().toISOString()}</small></p>
-      `,
-    });
-
-    if (response.error) {
-      console.error('Email configuration test failed:', summarizeResendError(response.error));
-      return false;
-    }
-
+  if (result.sent) {
     console.log(`✅ Test email sent successfully to ${recipientEmail}`);
-    return true;
-  } catch (error) {
-    console.error('Email configuration test failed:', summarizeResendError(error));
-    return false;
   }
+  return result.sent;
 }
 
 /**
@@ -100,46 +107,30 @@ export async function sendPasswordRegeneratedEmail(params: {
   userEmail: string;
   password: string;
 }): Promise<boolean> {
-  const apiKey = getApiKey();
-  const from = getFromAddress();
+  const result = await sendViaCameraEmailService({
+    to: params.userEmail,
+    subject: '🔐 {messmass} Access Password Regenerated',
+    html: `
+      <h2>Access Password Regenerated</h2>
+      <p>A new access password has been generated for your account on {messmass}.</p>
+      <div style="background: #f3f4f6; padding: 1.5rem; border-radius: 8px; margin: 1.5rem 0; text-align: center;">
+        <p style="margin-bottom: 0.5rem; color: #4b5563; font-size: 0.875rem;">Your new password:</p>
+        <code style="font-size: 1.5rem; font-weight: bold; color: #111827; letter-spacing: 0.05em;">${params.password}</code>
+      </div>
+      <hr>
+      <p><strong>Security Instructions:</strong></p>
+      <ul>
+        <li>Use your email (${params.userEmail}) and the password above to log in.</li>
+        <li>For security, please do not share this password with anyone.</li>
+      </ul>
+      <p><small>This is an automated security message from {messmass}.</small></p>
+    `,
+  });
 
-  if (!apiKey || !from) {
-    console.error('Failed to send password email: Resend is not configured (RESEND_API_KEY / EMAIL_FROM)');
-    return false;
-  }
-
-  try {
-    const resend = new Resend(apiKey);
-    const response = await resend.emails.send({
-      from,
-      to: params.userEmail,
-      subject: '🔐 {messmass} Access Password Regenerated',
-      html: `
-        <h2>Access Password Regenerated</h2>
-        <p>A new access password has been generated for your account on {messmass}.</p>
-        <div style="background: #f3f4f6; padding: 1.5rem; border-radius: 8px; margin: 1.5rem 0; text-align: center;">
-          <p style="margin-bottom: 0.5rem; color: #4b5563; font-size: 0.875rem;">Your new password:</p>
-          <code style="font-size: 1.5rem; font-weight: bold; color: #111827; letter-spacing: 0.05em;">${params.password}</code>
-        </div>
-        <hr>
-        <p><strong>Security Instructions:</strong></p>
-        <ul>
-          <li>Use your email (${params.userEmail}) and the password above to log in.</li>
-          <li>For security, please do not share this password with anyone.</li>
-        </ul>
-        <p><small>This is an automated security message from {messmass}.</small></p>
-      `,
-    });
-
-    if (response.error) {
-      console.error('Failed to send password email:', summarizeResendError(response.error));
-      return false;
-    }
-
+  if (result.sent) {
     console.log(`✅ Password email sent to ${params.userEmail}`);
-    return true;
-  } catch (error) {
-    console.error('Failed to send password email:', summarizeResendError(error));
-    return false;
+  } else {
+    console.error('Failed to send password email:', result.error);
   }
+  return result.sent;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,6 @@
         "react": "^19.2.6",
         "react-chartjs-2": "^5.3.1",
         "react-dom": "^19.2.6",
-        "resend": "^6.12.4",
         "server-only": "^0.0.1",
         "typescript": "^5.6.3",
         "uuid": "^14.0.0",
@@ -2709,12 +2708,6 @@
         "react": "^18.2.0 || ^19.0.0",
         "react-dom": "^18.2.0 || ^19.0.0"
       }
-    },
-    "node_modules/@stablelib/base64": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
-      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
-      "license": "MIT"
     },
     "node_modules/@swc/helpers": {
       "version": "0.5.15",
@@ -5469,12 +5462,6 @@
         "iobuffer": "^5.3.2",
         "pako": "^2.1.0"
       }
-    },
-    "node_modules/fast-sha256": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
-      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
-      "license": "Unlicense"
     },
     "node_modules/fastq": {
       "version": "1.19.1",
@@ -8746,12 +8733,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/postal-mime": {
-      "version": "2.7.5",
-      "resolved": "https://registry.npmjs.org/postal-mime/-/postal-mime-2.7.5.tgz",
-      "integrity": "sha512-GNEXKvWFQnbgO5NlrGzVa0FmWzBZ24PersAWErttSg1Hjpf0ATxTwS5DOMGaOpTG6bUh5cTr7xi0jAD942wCJA==",
-      "license": "MIT-0"
-    },
     "node_modules/postcss": {
       "version": "8.5.13",
       "funding": [
@@ -9095,27 +9076,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/resend": {
-      "version": "6.18.1",
-      "resolved": "https://registry.npmjs.org/resend/-/resend-6.18.1.tgz",
-      "integrity": "sha512-XN8XIaDdKF+ziSQ3K23ndUcyhP7U3ze2gky6SPgYkuAOq54mH4Wdhwm7QylEQ3zlz0NzdX7/l1AgmJUZbdPI/Q==",
-      "license": "MIT",
-      "dependencies": {
-        "postal-mime": "2.7.5",
-        "standardwebhooks": "1.0.0"
-      },
-      "engines": {
-        "node": ">=20"
-      },
-      "peerDependencies": {
-        "@react-email/render": "*"
-      },
-      "peerDependenciesMeta": {
-        "@react-email/render": {
-          "optional": true
-        }
       }
     },
     "node_modules/resolve": {
@@ -9572,16 +9532,6 @@
       "optional": true,
       "engines": {
         "node": ">=0.1.14"
-      }
-    },
-    "node_modules/standardwebhooks": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
-      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
-      "license": "MIT",
-      "dependencies": {
-        "@stablelib/base64": "^1.0.0",
-        "fast-sha256": "^1.3.0"
       }
     },
     "node_modules/stop-iteration-iterator": {

--- a/package.json
+++ b/package.json
@@ -162,7 +162,6 @@
     "react": "^19.2.6",
     "react-chartjs-2": "^5.3.1",
     "react-dom": "^19.2.6",
-    "resend": "^6.12.4",
     "server-only": "^0.0.1",
     "typescript": "^5.6.3",
     "uuid": "^14.0.0",

--- a/scripts/check-dependency-guardrail.ts
+++ b/scripts/check-dependency-guardrail.ts
@@ -45,7 +45,6 @@ const APPROVED_RUNTIME_DEPS = new Set([
   'js-cookie',
   'jspdf',
   'lucide-react',
-  'resend',
   'server-only',
   'typescript',
   'uuid',

--- a/scripts/test-email-notifications.ts
+++ b/scripts/test-email-notifications.ts
@@ -1,6 +1,7 @@
 // scripts/test-email-notifications.ts
 // WHAT: Test email notification system
-// WHY: Verify Resend credentials + sender identity work before production use
+// WHY: Verify camera's shared internal email service is reachable and configured
+//      before relying on it in production (see lib/emailNotifications.ts)
 
 import { testEmailConfig } from '../lib/emailNotifications';
 
@@ -28,9 +29,9 @@ async function runTest() {
   } else {
     console.log('\n❌ Failed to send test email.');
     console.log('💡 Troubleshooting:');
-    console.log('   1. Verify RESEND_API_KEY is set in .env.local');
-    console.log('   2. Verify EMAIL_FROM is a verified sending identity in Resend');
-    console.log('   3. Check the Resend dashboard for delivery/API errors');
+    console.log('   1. Verify CAMERA_BASE_URL and CAMERA_MESSMASS_INTERNAL_SECRET are set in .env.local');
+    console.log('   2. Confirm camera itself has RESEND_API_KEY / CAMERA_EMAIL_FROM configured');
+    console.log('   3. Check camera\'s logs / the Resend dashboard for delivery/API errors');
     process.exit(1);
   }
 }


### PR DESCRIPTION
## Summary
- Replaces the direct Resend SDK integration (added in a prior PR) with a call to camera's new `POST /api/internal/email/send` (camera PR #90) — camera is the one app in the stack with a working Resend account and verified sending domain, so messmass no longer needs its own.
- Removes the `resend` npm dependency and `RESEND_API_KEY`/`EMAIL_FROM` entirely.
- Auth reuses `CAMERA_BASE_URL` + `CAMERA_MESSMASS_INTERNAL_SECRET` — the same credentials already used for messmass → camera provisioning, not a new secret to manage.
- Same public API (`testEmailConfig`, `sendPasswordRegeneratedEmail`), same callers unaffected.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint` — clean
- [x] Dependency guardrail passes
- [x] `npm test` — 309/309 passing
- [x] Verified end-to-end against a **live local camera instance**: messmass reached camera, camera authenticated the request, attempted the Resend send, and the real Resend rejection propagated back correctly — confirms the full messmass → camera → Resend chain, not just each half in isolation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01A4Mf2crWQydtCABm2ebETJ)_