### PR TITLE
feat(partners): receive bidirectional partner sync from camera

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -83,7 +83,9 @@ JWT_SECRET=
 # --- messmass -> camera provisioning (messmass is master for orgs/partners/events) ---
 # When set, creating an event auto-provisions the mirror event in camera.
 # Also doubles as the auth for camera's shared email service (lib/emailNotifications.ts)
-# — same secret, same trust boundary, not a second credential to manage.
+# AND for validating inbound camera -> messmass partner-sync requests
+# (app/api/integrations/camera/partners/route.ts, lib/cameraPartnerSync.ts) —
+# same secret, same trust boundary, both directions, not a second credential to manage.
 CAMERA_BASE_URL=http://localhost:3000
 CAMERA_MESSMASS_INTERNAL_SECRET=
 

--- a/app/api/integrations/camera/partners/route.ts
+++ b/app/api/integrations/camera/partners/route.ts
@@ -1,0 +1,59 @@
+// app/api/integrations/camera/partners/route.ts
+// WHAT: Inbound endpoint receiving partner data pushed FROM camera -- the
+//     reverse of camera's own /api/internal/messmass/partners (which receives
+//     messmass -> camera pushes). Lets partners created directly in camera's
+//     admin UI flow back into messmass instead of only existing on camera's side.
+// WHY: Bidirectional partner sync, requested after users noticed camera-native
+//     partners never appeared in messmass.
+// AUTH: reuses the SAME shared secret already used for the forward direction
+//     (CAMERA_MESSMASS_INTERNAL_SECRET / config.cameraProvisionToken) -- both
+//     apps already hold this value, no new secret to manage.
+
+import { NextRequest, NextResponse } from 'next/server';
+import config from '@/lib/config';
+import { upsertPartnerFromCamera } from '@/lib/cameraPartnerSync';
+import { error as logError } from '@/lib/logger';
+
+function assertCameraSecret(request: NextRequest): NextResponse | null {
+  const configured = config.cameraProvisionToken;
+  if (!configured) {
+    return NextResponse.json({ success: false, error: 'camera_integration_not_configured' }, { status: 503 });
+  }
+  const auth = request.headers.get('authorization') || '';
+  const bearer = auth.startsWith('Bearer ') ? auth.slice(7).trim() : '';
+  const headerSecret = request.headers.get('x-camera-secret')?.trim() || '';
+  if (bearer !== configured && headerSecret !== configured) {
+    return NextResponse.json({ success: false, error: 'invalid_camera_secret' }, { status: 401 });
+  }
+  return null;
+}
+
+export async function POST(request: NextRequest) {
+  const authError = assertCameraSecret(request);
+  if (authError) return authError;
+
+  let body: Record<string, unknown>;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ success: false, error: 'invalid_json' }, { status: 400 });
+  }
+
+  const cameraPartnerId = String(body?.cameraPartnerId || '').trim();
+  const name = String(body?.name || '').trim();
+  if (!cameraPartnerId || !name) {
+    return NextResponse.json({ success: false, error: 'cameraPartnerId and name are required' }, { status: 400 });
+  }
+
+  try {
+    const partner = await upsertPartnerFromCamera({
+      cameraPartnerId,
+      name,
+      logoUrl: typeof body?.logoUrl === 'string' ? body.logoUrl : undefined,
+    });
+    return NextResponse.json({ success: true, partner });
+  } catch (error) {
+    logError('Camera partner sync failed', { cameraPartnerId }, error instanceof Error ? error : new Error(String(error)));
+    return NextResponse.json({ success: false, error: 'sync_failed' }, { status: 500 });
+  }
+}

--- a/lib/cameraPartnerSync.ts
+++ b/lib/cameraPartnerSync.ts
@@ -1,0 +1,80 @@
+// lib/cameraPartnerSync.ts
+// WHAT: Receives partner data pushed FROM camera (the reverse of
+//     lib/cameraProvision.ts, which pushes messmass partners TO camera).
+// WHY: Partners created directly in camera's own admin UI have no messmass
+//     equivalent unless something links them. This mirrors camera's own
+//     upsertPartner() hybrid-match logic (lib/messmass/provision.ts on the
+//     camera side) so both directions behave the same way: link an existing
+//     partner by camera id, else by case-insensitive name, else create one.
+// LOOP SAFETY: this never calls back into lib/cameraProvision.ts/cameraClient.ts
+//     to push the result back to camera -- that's what prevents ping-pong.
+//     Partners synced messmass->camera already carry `source: 'messmass'` on
+//     camera's side, and camera only pushes back partners where
+//     `source !== 'messmass'`, so a messmass-sourced partner can never round-trip.
+
+import getDb from './db';
+import { generateUniquePartnerViewSlug } from './partnerIdentifier';
+import { syncPartnerToV3Entity } from './v3/syncEngine';
+
+function ci(name: string) {
+  return { $regex: `^${name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}$`, $options: 'i' };
+}
+
+function nowIso(): string {
+  return new Date().toISOString();
+}
+
+async function ensureCameraPartnerIdIndex(db: Awaited<ReturnType<typeof getDb>>) {
+  try {
+    await db.collection('partners').createIndex({ cameraPartnerId: 1 }, { sparse: true });
+  } catch {
+    // ignore if exists
+  }
+}
+
+export async function upsertPartnerFromCamera(input: {
+  cameraPartnerId: string;
+  name: string;
+  logoUrl?: string;
+}): Promise<{ id: string; name: string; created: boolean; linked: boolean }> {
+  const db = await getDb();
+  await ensureCameraPartnerIdIndex(db);
+  const name = String(input.name || '').trim();
+  const now = nowIso();
+
+  const alreadyLinked = await db.collection('partners').findOne({ cameraPartnerId: input.cameraPartnerId });
+  const partner = alreadyLinked || (name ? await db.collection('partners').findOne({ name: ci(name) }) : null);
+
+  if (partner) {
+    const set: Record<string, unknown> = { updatedAt: now, cameraPartnerId: input.cameraPartnerId };
+    if (alreadyLinked) {
+      // WHAT: This partner was linked on a previous call -- keep propagating edits.
+      // WHY: The first link (matched by name) intentionally leaves name/logo alone
+      //   below, since a name match alone doesn't mean "camera owns this field."
+      //   Once linked by id, camera IS the source for its own edits, so sync them.
+      if (name) set.name = name;
+      if (input.logoUrl) set.logoUrl = input.logoUrl;
+    } else if (input.logoUrl && !partner.logoUrl) {
+      set.logoUrl = input.logoUrl;
+    }
+    await db.collection('partners').updateOne({ _id: partner._id }, { $set: set });
+    return { id: String(partner._id), name: (set.name as string) || partner.name, created: false, linked: true };
+  }
+
+  const viewSlug = await generateUniquePartnerViewSlug(db);
+  const partnerData: Record<string, unknown> = {
+    name,
+    emoji: '📷', // messmass requires an emoji; camera-sourced partners get a default
+    hashtags: [],
+    categorizedHashtags: {},
+    logoUrl: input.logoUrl || undefined,
+    viewSlug,
+    source: 'camera',
+    cameraPartnerId: input.cameraPartnerId,
+    createdAt: now,
+    updatedAt: now,
+  };
+  const result = await db.collection('partners').insertOne(partnerData);
+  syncPartnerToV3Entity({ ...partnerData, _id: result.insertedId } as any).catch(() => {});
+  return { id: String(result.insertedId), name, created: true, linked: false };
+}

--- a/lib/partner.types.ts
+++ b/lib/partner.types.ts
@@ -137,10 +137,20 @@ export interface Partner {
   // Metadata
   createdAt: string; // ISO 8601 with milliseconds
   updatedAt: string; // ISO 8601 with milliseconds
-  
+
   // WHAT: Draft flag for auto-created partners
   // WHY: Identify entities created by automation for later review
   isDraft?: boolean;
+
+  // WHAT: Where this partner record originated (unset = created directly in messmass)
+  // WHY: Distinguishes partners synced in from camera/fanmass vs. messmass-native ones;
+  //   also used to prevent sync ping-pong (see lib/cameraPartnerSync.ts)
+  source?: 'messmass' | 'fanmass' | 'camera';
+
+  // WHAT: Linked camera partner id (camera's `partnerId`, a UUID -- not a Mongo _id)
+  // WHY: Shared identity with camera, set by lib/cameraProvision.ts (messmass -> camera)
+  //   or lib/cameraPartnerSync.ts (camera -> messmass), whichever direction linked first
+  cameraPartnerId?: string;
   
   // WHAT: Google Sheets integration configuration (v12.0.0)
   // WHY: Enable automated event sync from Google Sheets to {messmass}


### PR DESCRIPTION
## Summary
- Adds `POST /api/integrations/camera/partners`, an inbound endpoint that receives partner data pushed from camera's own admin UI (the reverse of the existing messmass → camera provisioning that already runs on event creation).
- New `lib/cameraPartnerSync.ts` hybrid-matches by `cameraPartnerId` first, then case-insensitive `name`, else creates a new partner — mirroring camera's own `upsertPartner()` logic exactly.
- Adds `source` and `cameraPartnerId` fields to the `Partner` type (formalizing a field that was already being set ad-hoc by the forward-direction code).
- Auth reuses the existing shared `CAMERA_MESSMASS_INTERNAL_SECRET` — no new secret to manage.

## Why
Partners created directly in camera's admin UI never showed up in messmass. This closes that gap while preventing sync loops: partners that originated from messmass (`source: 'messmass'`) are never pushed back by camera, so a round-trip can't happen.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `eslint` clean on changed files
- [x] Verified live locally against throwaway MongoDB databases (not production): partner created in camera → linked into messmass; edits in camera propagate; partners with `source: 'messmass'` are never pushed back; name-collision correctly links instead of duplicating

---
_Generated by [Claude Code](https://claude.ai/code/session_01A4Mf2crWQydtCABm2ebETJ)_