### PR TITLE
fix(partners): batch and pace the camera backfill to respect rate limits

### DIFF
--- a/app/api/admin/sync-partners-to-camera/route.ts
+++ b/app/api/admin/sync-partners-to-camera/route.ts
@@ -1,6 +1,6 @@
 // app/api/admin/sync-partners-to-camera/route.ts
-// WHAT: One-click backfill -- pushes EVERY messmass partner that has never
-//     been linked to camera (no cameraPartnerId yet) over to camera now,
+// WHAT: One-click backfill -- pushes messmass partners that have never been
+//     linked to camera (no cameraPartnerId yet) over to camera now,
 //     regardless of whether an event has ever been created for them.
 // WHY: The only automatic trigger for messmass -> camera partner sync is
 //     event creation (see lib/cameraProvision.ts). Partners created before
@@ -8,15 +8,29 @@
 //     This is a GET so an already-logged-in admin can just open the URL.
 // HOW: Reuses lib/cameraProvision.ts's ensureCameraPartner() -- the exact
 //     same link-or-create logic that already runs on event creation.
+// RATE LIMIT: camera's internal-write endpoints allow 60 requests/60s per
+//     caller (see camera's lib/api/rateLimiter.ts INTERNAL_WRITE). Processes
+//     at most BATCH_SIZE partners per call, paced ~1.1s apart, to stay under
+//     that limit -- safe to just call this endpoint again (idempotent,
+//     already-linked partners are skipped) until `remaining` is 0.
 
-import { NextResponse } from 'next/server';
+import { NextResponse, type NextRequest } from 'next/server';
 import { getAdminUser } from '@/lib/auth';
 import getDb from '@/lib/db';
 import { ensureCameraPartner } from '@/lib/cameraProvision';
 import { cameraConfigured } from '@/lib/cameraClient';
 import { error as logError } from '@/lib/logger';
 
-export async function GET() {
+export const maxDuration = 60;
+
+const BATCH_SIZE = 35;
+const PACE_MS = 1000;
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export async function GET(request: NextRequest) {
   const admin = await getAdminUser();
   if (!admin || (admin.role !== 'admin' && admin.role !== 'superadmin')) {
     return NextResponse.json({ error: 'Admin access required' }, { status: 403 });
@@ -26,16 +40,20 @@ export async function GET() {
   }
 
   const db = await getDb();
+  const totalRemainingBefore = await db.collection('partners').countDocuments({ cameraPartnerId: { $exists: false } });
   const partners = await db
     .collection('partners')
     .find({ cameraPartnerId: { $exists: false } })
+    .limit(BATCH_SIZE)
     .toArray();
 
   let linked = 0;
   let failed = 0;
   const failures: Array<{ id: string; name: string; error: string }> = [];
 
-  for (const partner of partners) {
+  for (let i = 0; i < partners.length; i++) {
+    if (i > 0) await sleep(PACE_MS);
+    const partner = partners[i];
     try {
       const cameraPartnerId = await ensureCameraPartner(db, partner._id);
       if (cameraPartnerId) {
@@ -52,11 +70,15 @@ export async function GET() {
     }
   }
 
+  const remaining = totalRemainingBefore - linked;
+
   return NextResponse.json({
     success: true,
-    scanned: partners.length,
+    processedThisCall: partners.length,
     linked,
     failed,
+    remaining,
+    note: remaining > 0 ? 'Rate-limited to a safe batch size -- open this same URL again to continue.' : 'All partners linked.',
     failures: failures.slice(0, 20),
   });
 }


### PR DESCRIPTION
## Summary
The first production run of `/api/admin/sync-partners-to-camera` linked 57/152 partners then hit camera's `INTERNAL_WRITE` rate limit (60 req/60s) for the remaining 95. Fixes it by processing at most 35 partners per call, paced 1s apart, and reporting a `remaining` count.

## Why
All 152 partners were being pushed in one tight sequential loop with no pacing, well over camera's 60/60s internal-write limit. The endpoint is already idempotent (skips already-linked partners), so batching + repeat calls is the safe fix rather than trying to push everything through in one shot.

## Test plan
- [x] `tsc --noEmit` / `eslint` clean
- [x] Batch math verified to stay safely under the 60s function timeout (35 items × ~1s pacing + call latency ≈ 45-50s)

---
_Generated by [Claude Code](https://claude.ai/code/session_01A4Mf2crWQydtCABm2ebETJ)_