### PR TITLE
feat(admin): repair mojibake in partner/organization/event names

### DIFF
--- a/app/api/admin/fix-mojibake-text/route.ts
+++ b/app/api/admin/fix-mojibake-text/route.ts
@@ -1,0 +1,95 @@
+// app/api/admin/fix-mojibake-text/route.ts
+// WHAT: Scans partners.name, organizations.name, and projects.eventName for
+//     Windows-1252-decoded-as-UTF-8 mojibake (e.g. "VÃ¡ci" -> "Váci") and,
+//     when explicitly confirmed, repairs it in place.
+// WHY: This is stored data corruption, not a display bug -- it needs to be
+//     fixed once in the database, not worked around per-view.
+// HOW: Defaults to a dry run (reports what WOULD change, writes nothing).
+//     Pass ?apply=1 to actually write the fixes. lib/textRepair.ts's
+//     repairMojibake() never guesses -- it only returns a value for text
+//     that's PROVABLY one layer of this specific corruption, so it's safe
+//     to run repeatedly and safe on text in any other language/script.
+
+import { NextRequest, NextResponse } from 'next/server';
+import { ObjectId } from 'mongodb';
+import { getAdminUser } from '@/lib/auth';
+import getDb from '@/lib/db';
+import { repairMojibake } from '@/lib/textRepair';
+
+const CAP_PER_COLLECTION = 5000;
+
+interface Candidate {
+  id: string;
+  before: string;
+  after: string;
+}
+
+async function scanCollection(
+  db: Awaited<ReturnType<typeof getDb>>,
+  collection: string,
+  field: string
+): Promise<{ candidates: Candidate[]; scanned: number }> {
+  const cursor = db.collection(collection).find(
+    { [field]: { $type: 'string' } },
+    { projection: { [field]: 1 } }
+  ).limit(CAP_PER_COLLECTION);
+  const docs = await cursor.toArray();
+  const candidates: Candidate[] = [];
+  for (const doc of docs) {
+    const before = doc[field] as string;
+    const after = repairMojibake(before);
+    if (after !== null) {
+      candidates.push({ id: String(doc._id), before, after });
+    }
+  }
+  return { candidates, scanned: docs.length };
+}
+
+const TARGETS: Array<{ collection: string; field: string }> = [
+  { collection: 'partners', field: 'name' },
+  { collection: 'organizations', field: 'name' },
+  { collection: 'projects', field: 'eventName' },
+];
+
+export async function GET(request: NextRequest) {
+  const admin = await getAdminUser();
+  if (!admin || (admin.role !== 'admin' && admin.role !== 'superadmin')) {
+    return NextResponse.json({ error: 'Admin access required' }, { status: 403 });
+  }
+
+  const apply = request.nextUrl.searchParams.get('apply') === '1';
+  const db = await getDb();
+
+  const results: Record<string, { scanned: number; candidateCount: number; sample: Candidate[]; applied?: number }> = {};
+
+  for (const target of TARGETS) {
+    const { candidates, scanned } = await scanCollection(db, target.collection, target.field);
+    const key = `${target.collection}.${target.field}`;
+    results[key] = {
+      scanned,
+      candidateCount: candidates.length,
+      sample: candidates.slice(0, 15),
+    };
+
+    if (apply && candidates.length > 0) {
+      let applied = 0;
+      for (const c of candidates) {
+        await db.collection(target.collection).updateOne(
+          { _id: new ObjectId(c.id) },
+          { $set: { [target.field]: c.after } }
+        );
+        applied++;
+      }
+      results[key].applied = applied;
+    }
+  }
+
+  return NextResponse.json({
+    success: true,
+    mode: apply ? 'applied' : 'dry_run',
+    note: apply
+      ? 'Fixes have been written.'
+      : 'No changes written. Re-open this same URL with ?apply=1 to actually fix these.',
+    results,
+  });
+}

--- a/lib/textRepair.ts
+++ b/lib/textRepair.ts
@@ -1,0 +1,49 @@
+// lib/textRepair.ts
+// WHAT: Detects and repairs "mojibake" text -- valid UTF-8 that was, at some
+//     earlier point (an old import), decoded as Windows-1252 and stored that
+//     way. Classic symptom: "Váci" stored/displayed as "VÃ¡ci".
+// WHY: Surfaced when partner names started appearing in camera via the sync
+//     backfill (e.g. "VÃ¡ci NKSE" instead of "Váci NKSE") -- the corruption
+//     was already in messmass's own database, sync just made it visible
+//     elsewhere.
+// HOW: repairMojibake() reverses ONE layer of "UTF-8 bytes shown as
+//     Windows-1252" by mapping each character back to its cp1252 byte value,
+//     then re-decoding those bytes as UTF-8. Returns null (never guesses) if
+//     the string isn't representable in cp1252, or the round-trip doesn't
+//     produce valid UTF-8 -- this is what makes it safe to run on already-
+//     correct text of ANY language/script: real multi-byte UTF-8 characters
+//     (á, ő, Ü, 北, ...) fail the round-trip and are left untouched.
+
+const CP1252_TO_CODEPOINT: number[] = (() => {
+  const dec = new TextDecoder('windows-1252');
+  const table: number[] = new Array(256);
+  for (let b = 0; b < 256; b++) {
+    table[b] = dec.decode(Buffer.from([b])).codePointAt(0)!;
+  }
+  return table;
+})();
+
+const CODEPOINT_TO_CP1252: Map<number, number> = new Map(
+  CP1252_TO_CODEPOINT.map((cp, byte) => [cp, byte])
+);
+
+/**
+ * repairMojibake
+ * Returns the repaired string if `str` is detectably "UTF-8 shown as
+ * Windows-1252" mojibake, or null if it isn't (including: already-correct
+ * text in any language, or text that just happens to not be representable
+ * this way). Never returns a guess -- only an exact, verified repair.
+ */
+export function repairMojibake(str: string): string | null {
+  if (!str) return null;
+  const bytes: number[] = [];
+  for (const ch of str) {
+    const byte = CODEPOINT_TO_CP1252.get(ch.codePointAt(0)!);
+    if (byte === undefined) return null;
+    bytes.push(byte);
+  }
+  const repaired = Buffer.from(bytes).toString('utf8');
+  if (repaired.includes('�')) return null; // invalid UTF-8 -- not a match
+  if (repaired === str) return null; // nothing to fix
+  return repaired;
+}


### PR DESCRIPTION
## Summary
- New `lib/textRepair.ts`: reverses one layer of "UTF-8 decoded as Windows-1252" corruption (e.g. `"VÃ¡ci NKSE"` → `"Váci NKSE"`), the root cause of the garbled Hungarian partner names surfaced by the camera sync backfill.
- New `GET /api/admin/fix-mojibake-text` scans `partners.name`, `organizations.name`, `projects.eventName`. Dry run by default; `?apply=1` writes the fixes.

## Why
The corrupted text was already stored this way in messmass's own database (from some earlier import) — the camera sync just made it visible elsewhere. This fixes it at the source.

## Safety
`repairMojibake()` never guesses: it only returns a repaired string when the byte round-trip through cp1252 produces valid, different UTF-8. Verified this makes it a no-op on already-correct text in any language — tested against correct Hungarian, Spanish, French, Turkish, and CJK strings, none altered.

## Test plan
- [x] `tsc --noEmit` / `eslint` clean
- [x] Verified locally: dry run correctly identified only the 4 seeded corrupted entries (out of a mix including already-correct accented and CJK names); apply fixed exactly those; re-running afterward reports zero candidates

---
_Generated by [Claude Code](https://claude.ai/code/session_01A4Mf2crWQydtCABm2ebETJ)_