### PR TITLE
feat(auth): shared SSO session with camera (Phase 4)

### DIFF
--- a/app/api/auth/sso/callback/route.ts
+++ b/app/api/auth/sso/callback/route.ts
@@ -10,16 +10,6 @@
 //     isAdmin checks, /admin/dashboard gating) needs to change.
 
 import { NextRequest, NextResponse } from 'next/server';
-import crypto from 'crypto';
-import {
-  createUser,
-  findUserByEmail,
-  findUserBySsoId,
-  getUsersCollection,
-  updateUserLastLogin,
-  type UserRole,
-} from '@/lib/users';
-import { generateSessionToken, type SessionTokenData } from '@/lib/sessionTokens';
 import {
   decodeIdToken,
   exchangeCodeForToken,
@@ -28,19 +18,11 @@ import {
   shouldUseConfidentialOAuth,
 } from '@/lib/auth/ssoOAuth';
 import { getAppPermission, hasAppAccess, type AppPermission } from '@/lib/auth/ssoPermissions';
+import { mintMessmassSessionForSsoUser } from '@/lib/auth/mintSession';
 import { clearPendingOAuthCookie, readPendingOAuthCookie } from '@/lib/auth/oauthPendingCookie';
-import { logAuthSuccess, error as logError } from '@/lib/logger';
-import { FEATURE_FLAGS } from '@/lib/featureFlags';
+import { pushSsoSessionToCamera } from '@/lib/cameraClient';
+import { error as logError } from '@/lib/logger';
 import config from '@/lib/config';
-
-const AUTH_SOURCE_COOKIE = 'auth-source';
-
-/** SSO app-role -> messmass's local role set. 'none' is handled separately (access denied). */
-function mapSsoRoleToMessmassRole(ssoRole: AppPermission['role']): UserRole {
-  if (ssoRole === 'superadmin') return 'superadmin';
-  if (ssoRole === 'admin') return 'admin';
-  return 'user';
-}
 
 function redirectWithError(request: NextRequest, error: string): NextResponse {
   const response = NextResponse.redirect(new URL(`/admin/login?error=${error}`, request.url));
@@ -107,69 +89,29 @@ export async function GET(request: NextRequest) {
       return redirectWithError(request, 'no_access');
     }
 
-    // Resolve local user: by linked SSO id first, then by email (first-ever SSO
-    // login for an existing local account links it), else auto-provision.
-    let user = await findUserBySsoId(ssoUser.id);
-    if (!user) {
-      user = await findUserByEmail(ssoUser.email);
-    }
-
-    const mappedRole = mapSsoRoleToMessmassRole(permission.role);
-
-    if (!user) {
-      user = await createUser({
-        email: ssoUser.email,
-        name: ssoUser.name || ssoUser.email,
-        role: mappedRole,
-        ssoUserId: ssoUser.id,
-        createdAt: new Date().toISOString(),
-        updatedAt: new Date().toISOString(),
-      });
-    } else if (user.ssoUserId !== ssoUser.id || user.role !== mappedRole) {
-      // Keep the local cache in sync with SSO (source of truth for role).
-      const col = await getUsersCollection();
-      await col.updateOne(
-        { _id: user._id },
-        { $set: { ssoUserId: ssoUser.id, role: mappedRole, updatedAt: new Date().toISOString() } }
-      );
-      user = { ...user, ssoUserId: ssoUser.id, role: mappedRole };
-    }
-
-    const tokenData: SessionTokenData = {
-      token: crypto.randomBytes(32).toString('hex'),
-      expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString(),
-      userId: user._id!.toString(),
-      role: user.role,
-    };
-    const sessionToken = generateSessionToken(tokenData);
-
-    const isProduction = config.nodeEnv === 'production';
-    const host = request.headers.get('host') || '';
-    const domain = isProduction && host.endsWith('messmass.com') ? '.messmass.com' : undefined;
-    const cookieOpts = {
-      httpOnly: true,
-      secure: isProduction,
-      sameSite: 'lax' as const,
-      maxAge: 7 * 24 * 60 * 60,
-      path: '/' as const,
-      ...(domain && { domain }),
-    };
-
-    const userId = user._id!.toString();
-    try {
-      await updateUserLastLogin(userId);
-    } catch {
-      // non-fatal
-    }
-    logAuthSuccess(userId, request.headers.get('x-forwarded-for') || undefined);
-
     const safeRedirect = pending.redirectTo.startsWith('/admin') ? pending.redirectTo : '/admin';
     const response = NextResponse.redirect(new URL(safeRedirect, request.url));
     clearPendingOAuthCookie(response);
-    response.cookies.set('admin-session', sessionToken, cookieOpts);
-    response.cookies.set(AUTH_SOURCE_COOKIE, 'sso', { ...cookieOpts, httpOnly: false });
-    if (FEATURE_FLAGS.USE_JWT_SESSIONS) {
-      response.cookies.set('session-format', 'jwt', { ...cookieOpts, httpOnly: false });
+
+    const minted = await mintMessmassSessionForSsoUser(ssoUser, permission, request, response);
+    if (!minted) {
+      // hasAppAccess() already checked above; this is defense-in-depth only.
+      return redirectWithError(request, 'no_access');
+    }
+
+    // WHAT: Best-effort -- also log this user into camera, so one SSO login
+    //     covers both apps (see SESSION_COOKIE_DOMAIN=.messmass.com on
+    //     camera's side + lib/cameraClient.ts:pushSsoSessionToCamera).
+    // WHY: Never let this block or fail messmass's own login -- camera being
+    //     unreachable, or this user simply not having camera access, are
+    //     both fine outcomes; the user just won't be auto-logged into camera.
+    try {
+      const cameraCookies = await pushSsoSessionToCamera(tokens);
+      for (const cookie of cameraCookies || []) {
+        response.headers.append('set-cookie', cookie);
+      }
+    } catch (e) {
+      logError('Cross-app camera session push failed (non-fatal)', {}, e instanceof Error ? e : new Error(String(e)));
     }
 
     return response;

--- a/app/api/integrations/camera/partners/route.ts
+++ b/app/api/integrations/camera/partners/route.ts
@@ -10,23 +10,9 @@
 //     apps already hold this value, no new secret to manage.
 
 import { NextRequest, NextResponse } from 'next/server';
-import config from '@/lib/config';
+import { assertCameraSecret } from '@/lib/cameraClient';
 import { upsertPartnerFromCamera } from '@/lib/cameraPartnerSync';
 import { error as logError } from '@/lib/logger';
-
-function assertCameraSecret(request: NextRequest): NextResponse | null {
-  const configured = config.cameraProvisionToken;
-  if (!configured) {
-    return NextResponse.json({ success: false, error: 'camera_integration_not_configured' }, { status: 503 });
-  }
-  const auth = request.headers.get('authorization') || '';
-  const bearer = auth.startsWith('Bearer ') ? auth.slice(7).trim() : '';
-  const headerSecret = request.headers.get('x-camera-secret')?.trim() || '';
-  if (bearer !== configured && headerSecret !== configured) {
-    return NextResponse.json({ success: false, error: 'invalid_camera_secret' }, { status: 401 });
-  }
-  return null;
-}
 
 export async function POST(request: NextRequest) {
   const authError = assertCameraSecret(request);

--- a/app/api/integrations/camera/sso-session/route.ts
+++ b/app/api/integrations/camera/sso-session/route.ts
@@ -1,0 +1,85 @@
+// app/api/integrations/camera/sso-session/route.ts
+// WHAT: Mints a real messmass login session for a user who just logged into
+//     camera via SSO -- the reverse-direction sibling of camera's
+//     /api/internal/messmass/sso-session. Together these give a user who
+//     logs into EITHER app a session cookie for BOTH, without a second
+//     OAuth round-trip.
+// WHY: messmass and camera use completely different session formats
+//     (admin-session JWT vs camera_session) with no shared secret between
+//     them -- there's no way to "translate" one into the other without
+//     minting a real session through each app's own code.
+// PATH: lives under /api/integrations/ (not /api/internal/) so it's exempt
+//     from messmass's cookie-based CSRF middleware (lib/csrf.ts) -- this is
+//     a cookieless server-to-server call authed by a shared secret, not a
+//     browser session, so double-submit-cookie CSRF protection doesn't apply
+//     (and would just 403 every legitimate call). Same reasoning as the
+//     existing /api/integrations/camera/partners and
+//     /api/integrations/fanmass/* endpoints.
+// SECURITY: assertCameraSecret() only proves "this call came from our
+//     camera deployment" -- it does NOT by itself authorize minting a
+//     session for an arbitrary user id. This endpoint independently
+//     verifies the forwarded access token directly against SSO itself
+//     (getUserInfo + getAppPermission, using MESSMASS's own SSO_CLIENT_ID,
+//     exactly like the real OAuth callback does) -- never trusting a user
+//     id/role asserted by the caller.
+
+import { NextRequest, NextResponse } from 'next/server';
+import { assertCameraSecret } from '@/lib/cameraClient';
+import { checkRateLimit, RATE_LIMITS } from '@/lib/rateLimit';
+import { getUserInfo } from '@/lib/auth/ssoOAuth';
+import { getAppPermission, hasAppAccess } from '@/lib/auth/ssoPermissions';
+import { mintMessmassSessionForSsoUser } from '@/lib/auth/mintSession';
+import { error as logError } from '@/lib/logger';
+
+export async function POST(request: NextRequest) {
+  const authError = assertCameraSecret(request);
+  if (authError) return authError;
+
+  const forwardedFor = request.headers.get('x-forwarded-for');
+  const identifier = forwardedFor ? forwardedFor.split(',')[0].trim() : 'unknown';
+  const rl = checkRateLimit(`camera-sso-session:${identifier}`, RATE_LIMITS.WRITE);
+  if (!rl.allowed) {
+    return NextResponse.json({ success: false, error: RATE_LIMITS.WRITE.message }, { status: 429 });
+  }
+
+  let body: Record<string, unknown>;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ success: false, error: 'invalid_json' }, { status: 400 });
+  }
+
+  const accessToken = String(body?.accessToken || '').trim();
+  if (!accessToken) {
+    return NextResponse.json({ success: false, error: 'accessToken is required' }, { status: 400 });
+  }
+
+  let ssoUser;
+  try {
+    ssoUser = await getUserInfo(accessToken);
+  } catch {
+    return NextResponse.json({ success: false, error: 'invalid_token' }, { status: 401 });
+  }
+  if (!ssoUser.id) {
+    return NextResponse.json({ success: false, error: 'invalid_token' }, { status: 401 });
+  }
+
+  let permission;
+  try {
+    permission = await getAppPermission(ssoUser.id, accessToken);
+  } catch (e) {
+    logError('Failed to get messmass app permission for cross-app session', { ssoUserId: ssoUser.id }, e instanceof Error ? e : new Error(String(e)));
+    return NextResponse.json({ success: false, error: 'permission_check_failed' }, { status: 502 });
+  }
+
+  if (!hasAppAccess(permission)) {
+    return NextResponse.json({ success: false, error: 'no_access' }, { status: 403 });
+  }
+
+  const response = NextResponse.json({ success: true, role: permission.role });
+  const minted = await mintMessmassSessionForSsoUser(ssoUser, permission, request, response);
+  if (!minted) {
+    return NextResponse.json({ success: false, error: 'no_access' }, { status: 403 });
+  }
+  return response;
+}

--- a/lib/auth/mintSession.ts
+++ b/lib/auth/mintSession.ts
@@ -1,0 +1,119 @@
+// lib/auth/mintSession.ts
+// WHAT: Resolves/auto-provisions the local messmass user for an
+//     already-verified SSO identity + permission, mints a session token,
+//     and sets the admin-session (+ auth-source) cookies on `response`.
+// WHY: Shared by the browser-facing OAuth callback
+//     (app/api/auth/sso/callback) and the internal cross-app endpoint
+//     (app/api/internal/camera/sso-session) -- same login outcome either
+//     way, whichever app the user actually authenticated against. Extracted
+//     from the callback route (was previously inline there) so both call
+//     sites stay in sync automatically.
+
+import { NextRequest, NextResponse } from 'next/server';
+import crypto from 'crypto';
+import {
+  createUser,
+  findUserByEmail,
+  findUserBySsoId,
+  getUsersCollection,
+  updateUserLastLogin,
+  type UserRole,
+} from '@/lib/users';
+import { generateSessionToken, type SessionTokenData } from '@/lib/sessionTokens';
+import { hasAppAccess, type AppPermission } from '@/lib/auth/ssoPermissions';
+import { logAuthSuccess } from '@/lib/logger';
+import { FEATURE_FLAGS } from '@/lib/featureFlags';
+import config from '@/lib/config';
+
+const AUTH_SOURCE_COOKIE = 'auth-source';
+
+/** SSO app-role -> messmass's local role set. 'none' is handled via hasAppAccess() below. */
+function mapSsoRoleToMessmassRole(ssoRole: AppPermission['role']): UserRole {
+  if (ssoRole === 'superadmin') return 'superadmin';
+  if (ssoRole === 'admin') return 'admin';
+  return 'user';
+}
+
+export interface MintableSsoUser {
+  id: string;
+  email: string;
+  name?: string;
+}
+
+/**
+ * Returns null (and sets no cookies) if `permission` doesn't grant messmass
+ * access -- caller decides how to handle that (redirect with an error, or
+ * for the cross-app endpoint, a 403 JSON response).
+ */
+export async function mintMessmassSessionForSsoUser(
+  ssoUser: MintableSsoUser,
+  permission: AppPermission,
+  request: NextRequest,
+  response: NextResponse
+): Promise<{ userId: string; role: UserRole } | null> {
+  if (!hasAppAccess(permission)) return null;
+
+  // Resolve local user: by linked SSO id first, then by email (first-ever SSO
+  // login for an existing local account links it), else auto-provision.
+  let user = await findUserBySsoId(ssoUser.id);
+  if (!user) {
+    user = await findUserByEmail(ssoUser.email);
+  }
+
+  const mappedRole = mapSsoRoleToMessmassRole(permission.role);
+
+  if (!user) {
+    user = await createUser({
+      email: ssoUser.email,
+      name: ssoUser.name || ssoUser.email,
+      role: mappedRole,
+      ssoUserId: ssoUser.id,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    });
+  } else if (user.ssoUserId !== ssoUser.id || user.role !== mappedRole) {
+    // Keep the local cache in sync with SSO (source of truth for role).
+    const col = await getUsersCollection();
+    await col.updateOne(
+      { _id: user._id },
+      { $set: { ssoUserId: ssoUser.id, role: mappedRole, updatedAt: new Date().toISOString() } }
+    );
+    user = { ...user, ssoUserId: ssoUser.id, role: mappedRole };
+  }
+
+  const tokenData: SessionTokenData = {
+    token: crypto.randomBytes(32).toString('hex'),
+    expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString(),
+    userId: user._id!.toString(),
+    role: user.role,
+  };
+  const sessionToken = generateSessionToken(tokenData);
+
+  const isProduction = config.nodeEnv === 'production';
+  const host = request.headers.get('host') || '';
+  const domain = isProduction && host.endsWith('messmass.com') ? '.messmass.com' : undefined;
+  const cookieOpts = {
+    httpOnly: true,
+    secure: isProduction,
+    sameSite: 'lax' as const,
+    maxAge: 7 * 24 * 60 * 60,
+    path: '/' as const,
+    ...(domain && { domain }),
+  };
+
+  const userId = user._id!.toString();
+  try {
+    await updateUserLastLogin(userId);
+  } catch {
+    // non-fatal
+  }
+  logAuthSuccess(userId, request.headers.get('x-forwarded-for') || undefined);
+
+  response.cookies.set('admin-session', sessionToken, cookieOpts);
+  response.cookies.set(AUTH_SOURCE_COOKIE, 'sso', { ...cookieOpts, httpOnly: false });
+  if (FEATURE_FLAGS.USE_JWT_SESSIONS) {
+    response.cookies.set('session-format', 'jwt', { ...cookieOpts, httpOnly: false });
+  }
+
+  return { userId, role: user.role };
+}

--- a/lib/cameraClient.ts
+++ b/lib/cameraClient.ts
@@ -3,7 +3,29 @@
  * calls camera's token-authed /api/internal/messmass/* endpoints to create/link
  * organisations, partners and events. Auth = shared secret (config.cameraProvisionToken).
  */
+import { NextRequest, NextResponse } from 'next/server';
 import config from '@/lib/config';
+
+/**
+ * WHAT: Validates an inbound request claims to be camera, via the same
+ *     shared secret used for the forward (messmass -> camera) direction.
+ * WHY: Reused by every camera -> messmass inbound endpoint
+ *     (app/api/integrations/camera/partners, app/api/internal/camera/sso-session)
+ *     so the check stays in exactly one place.
+ */
+export function assertCameraSecret(request: NextRequest): NextResponse | null {
+  const configured = config.cameraProvisionToken;
+  if (!configured) {
+    return NextResponse.json({ success: false, error: 'camera_integration_not_configured' }, { status: 503 });
+  }
+  const auth = request.headers.get('authorization') || '';
+  const bearer = auth.startsWith('Bearer ') ? auth.slice(7).trim() : '';
+  const headerSecret = request.headers.get('x-camera-secret')?.trim() || '';
+  if (bearer !== configured && headerSecret !== configured) {
+    return NextResponse.json({ success: false, error: 'invalid_camera_secret' }, { status: 401 });
+  }
+  return null;
+}
 
 function base(): string {
   return (config.cameraBaseUrl || '').replace(/\/$/, '');
@@ -30,6 +52,46 @@ async function req(method: string, path: string, body?: unknown): Promise<Record
     throw new Error(`camera_${res.status}:${JSON.stringify(json).slice(0, 200)}`);
   }
   return (json.data !== undefined ? json.data : json) as Record<string, unknown>;
+}
+
+/**
+ * WHAT: Best-effort cross-app login -- forwards the SSO tokens messmass just
+ *     received to camera's /api/internal/messmass/sso-session, which
+ *     independently re-verifies them against SSO and mints a REAL camera
+ *     session if the user has camera access. Returns the Set-Cookie
+ *     header(s) camera produced (to be appended onto messmass's own
+ *     response), or null if camera is unconfigured, unreachable, or the
+ *     user doesn't have camera access -- all non-fatal, never throws.
+ * WHY: Together with SESSION_COOKIE_DOMAIN=.messmass.com on camera's side,
+ *     this is what makes "log into messmass -> also logged into camera"
+ *     work without a second OAuth round-trip. See docs/... shared session.
+ */
+export async function pushSsoSessionToCamera(tokens: {
+  access_token: string;
+  refresh_token: string;
+  expires_in: number;
+}): Promise<string[] | null> {
+  if (!cameraConfigured()) return null;
+  try {
+    const res = await fetch(`${base()}/api/internal/messmass/sso-session`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'x-messmass-secret': token(),
+        authorization: `Bearer ${token()}`,
+      },
+      body: JSON.stringify({
+        accessToken: tokens.access_token,
+        refreshToken: tokens.refresh_token,
+        expiresIn: tokens.expires_in,
+      }),
+    });
+    if (!res.ok) return null;
+    const cookies = typeof res.headers.getSetCookie === 'function' ? res.headers.getSetCookie() : [];
+    return cookies.length ? cookies : null;
+  } catch {
+    return null;
+  }
 }
 
 export const cameraClient = {


### PR DESCRIPTION
## Summary
Logging into messmass via SSO now also logs the user into camera (and vice versa), without a second OAuth click.

- `lib/auth/mintSession.ts` (new): the local-user find-or-create + role-sync + session-token + cookie logic, extracted out of the browser callback so it's shared with the new cross-app endpoint (no behavior change to the existing flow).
- `POST /api/integrations/camera/sso-session` (new): receives SSO tokens forwarded from camera's own callback, independently re-verifies them against SSO with messmass's own `SSO_CLIENT_ID` (never trusts an asserted user id), mints a real messmass session.
- messmass's own callback now best-effort pushes its tokens to camera's mirror endpoint and forwards the resulting `Set-Cookie` onto its own response.
- Lives under `/api/integrations/` (not `/api/internal/`) — exempt from the cookie-based CSRF middleware, same reasoning as the existing `/api/integrations/camera/partners` endpoint.

## Security
The shared secret alone only proves "this call came from our camera deployment" — minting a session additionally requires the forwarded access token to independently check out against SSO itself, bounding a leaked secret to "sessions for users with a currently-live SSO token," not arbitrary impersonation.

## Test plan
- [x] `tsc --noEmit` / `eslint` clean
- [x] Verified end-to-end locally with a fake SSO server: a real request through messmass's actual callback route produces both its own `admin-session` AND a real forwarded `camera_session` cookie in one response
- [x] Reverse direction verified the same way through camera's actual callback
- [x] Confirmed a user without camera access still gets a normal messmass login, camera cookie simply absent
- [x] Confirmed invalid tokens and wrong shared secrets are rejected

---
_Generated by [Claude Code](https://claude.ai/code/session_01A4Mf2crWQydtCABm2ebETJ)_