### PR TITLE
Make logout actually end the SSO session

### DIFF
--- a/app/api/admin/login/route.ts
+++ b/app/api/admin/login/route.ts
@@ -80,13 +80,31 @@ export async function DELETE(request: NextRequest) {
       path: '/',
       domain,
     })
+    // SECURITY: no `domain` here -- sso-tokens is minted host-only
+    // (see mintSession.ts), so clearing it with the shared `.messmass.com`
+    // domain wouldn't actually remove the host-only cookie the browser has.
     response.cookies.set('sso-tokens', '', {
       httpOnly: true,
       secure: isProduction,
       sameSite: 'lax',
       maxAge: 0,
       path: '/',
-      domain,
+    })
+
+    // WHAT: Short-lived, non-sensitive marker so the very next SSO login
+    //     attempt (however the user reaches it -- a dashboard link, a
+    //     bookmark, /admin/login's own auto-redirect) forces SSO to show
+    //     its real login screen instead of silently re-approving.
+    // WHY: Revoking this app's SSO tokens doesn't end SSO's own browser
+    //     session. Without this, only a login initiated with an explicit
+    //     ?from_logout=true got prompt=login -- every other path back into
+    //     SSO right after logout would just silently sign the user back in.
+    response.cookies.set('post-logout', '1', {
+      httpOnly: true,
+      secure: isProduction,
+      sameSite: 'lax',
+      maxAge: 120,
+      path: '/',
     })
 
     return response

--- a/app/api/admin/login/route.ts
+++ b/app/api/admin/login/route.ts
@@ -4,8 +4,10 @@
 // WHY: SSO_EMAIL_UNIFICATION_PLAN.md Phase 4 follow-up. Having a parallel local
 //     login meant messmass genuinely had two separate user systems instead of
 //     one unified one.
-// NOTE: DELETE (logout) is unchanged and still works for any existing session,
-//     regardless of whether it was minted via SSO or (historically) locally.
+// NOTE: DELETE (logout) also revokes the SSO access/refresh tokens minted at
+//     login (best-effort) -- clearing only messmass's own cookie left the
+//     SSO tokens (and often SSO's own browser session) alive, so the next
+//     SSO redirect would silently sign the user back in.
 
 export const runtime = 'nodejs'
 
@@ -13,6 +15,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { cookies } from 'next/headers'
 import { env } from '@/lib/config'
 import { error as logError } from '@/lib/logger'
+import { revokeToken } from '@/lib/auth/ssoOAuth'
 
 export async function POST() {
   return NextResponse.json(
@@ -31,11 +34,33 @@ export async function DELETE(request: NextRequest) {
     const host = request.headers.get('host') || ''
     const domain = isProduction && host.endsWith('messmass.com') ? '.messmass.com' : undefined
 
-    // WHAT: Delete session cookie
+    // WHAT: Revoke the SSO tokens minted at login, if any (best-effort --
+    //     revocation failure must never block local logout).
+    // WHY: Ending messmass's own session isn't enough on its own; the SSO
+    //     tokens (and the access SSO itself grants from them) should die too.
+    const ssoTokensRaw = cookieStore.get('sso-tokens')?.value
+    if (ssoTokensRaw) {
+      try {
+        const ssoTokens = JSON.parse(ssoTokensRaw) as { access_token?: string; refresh_token?: string }
+        if (ssoTokens.access_token) {
+          await revokeToken(ssoTokens.access_token, 'access_token')
+        }
+        if (ssoTokens.refresh_token) {
+          await revokeToken(ssoTokens.refresh_token, 'refresh_token')
+        }
+      } catch (revokeError) {
+        logError('SSO token revocation failed (non-blocking)', {
+          pathname: '/api/admin/login',
+          method: 'DELETE',
+        }, revokeError instanceof Error ? revokeError : new Error(String(revokeError)))
+      }
+    }
+
+    // WHAT: Delete session cookies
     // WHY: Invalidate user session on logout
     cookieStore.delete('admin-session')
-
     cookieStore.delete('auth-source')
+    cookieStore.delete('sso-tokens')
 
     // Also set explicit deletion response cookie
     const response = NextResponse.json({ success: true, message: 'Logged out successfully' })
@@ -49,6 +74,14 @@ export async function DELETE(request: NextRequest) {
     })
     response.cookies.set('auth-source', '', {
       httpOnly: false,
+      secure: isProduction,
+      sameSite: 'lax',
+      maxAge: 0,
+      path: '/',
+      domain,
+    })
+    response.cookies.set('sso-tokens', '', {
+      httpOnly: true,
       secure: isProduction,
       sameSite: 'lax',
       maxAge: 0,

--- a/app/api/auth/sso/callback/route.ts
+++ b/app/api/auth/sso/callback/route.ts
@@ -93,7 +93,10 @@ export async function GET(request: NextRequest) {
     const response = NextResponse.redirect(new URL(safeRedirect, request.url));
     clearPendingOAuthCookie(response);
 
-    const minted = await mintMessmassSessionForSsoUser(ssoUser, permission, request, response);
+    const minted = await mintMessmassSessionForSsoUser(ssoUser, permission, request, response, {
+      access_token: tokens.access_token,
+      refresh_token: tokens.refresh_token,
+    });
     if (!minted) {
       // hasAppAccess() already checked above; this is defense-in-depth only.
       return redirectWithError(request, 'no_access');

--- a/app/api/auth/sso/login/route.ts
+++ b/app/api/auth/sso/login/route.ts
@@ -31,10 +31,16 @@ export async function GET(request: NextRequest) {
   const redirectToParam = request.nextUrl.searchParams.get('redirect_uri');
   const redirectTo = redirectToParam?.startsWith('/admin') ? redirectToParam : '/admin';
   const redirectUri = getOAuthCallbackRedirectUri(request);
+  // WHAT: Force SSO to show its real login screen instead of silently
+  //     re-approving an existing SSO browser session.
+  // WHY: Revoking this app's own SSO tokens at logout doesn't end the
+  //     session cookie SSO itself holds -- without this hint, signing back
+  //     in right after logging out can look like logout never happened.
+  const fromLogout = request.nextUrl.searchParams.get('from_logout') === 'true';
 
   if (shouldUseConfidentialOAuth()) {
     const state = generateState();
-    const authUrl = getAuthorizationUrl(null, state, { redirectUri });
+    const authUrl = getAuthorizationUrl(null, state, { redirectUri, prompt: fromLogout ? 'login' : undefined });
     const response = NextResponse.redirect(authUrl);
     setPendingOAuthCookie(response, { state, redirectTo });
     return response;
@@ -42,7 +48,7 @@ export async function GET(request: NextRequest) {
 
   const { codeVerifier, codeChallenge } = generatePKCEPair();
   const state = generateState();
-  const authUrl = getAuthorizationUrl(codeChallenge, state, { redirectUri });
+  const authUrl = getAuthorizationUrl(codeChallenge, state, { redirectUri, prompt: fromLogout ? 'login' : undefined });
   const response = NextResponse.redirect(authUrl);
   setPendingOAuthCookie(response, { state, codeVerifier, redirectTo });
   return response;

--- a/app/api/auth/sso/login/route.ts
+++ b/app/api/auth/sso/login/route.ts
@@ -36,20 +36,28 @@ export async function GET(request: NextRequest) {
   // WHY: Revoking this app's own SSO tokens at logout doesn't end the
   //     session cookie SSO itself holds -- without this hint, signing back
   //     in right after logging out can look like logout never happened.
-  const fromLogout = request.nextUrl.searchParams.get('from_logout') === 'true';
+  //     The post-logout cookie covers every path back into this route
+  //     (a dashboard link, a bookmark, /admin/login's own auto-redirect),
+  //     not just callers that explicitly pass ?from_logout=true.
+  const justLoggedOut = Boolean(request.cookies.get('post-logout')?.value);
+  const fromLogout = justLoggedOut || request.nextUrl.searchParams.get('from_logout') === 'true';
 
+  let response: NextResponse;
   if (shouldUseConfidentialOAuth()) {
     const state = generateState();
     const authUrl = getAuthorizationUrl(null, state, { redirectUri, prompt: fromLogout ? 'login' : undefined });
-    const response = NextResponse.redirect(authUrl);
+    response = NextResponse.redirect(authUrl);
     setPendingOAuthCookie(response, { state, redirectTo });
-    return response;
+  } else {
+    const { codeVerifier, codeChallenge } = generatePKCEPair();
+    const state = generateState();
+    const authUrl = getAuthorizationUrl(codeChallenge, state, { redirectUri, prompt: fromLogout ? 'login' : undefined });
+    response = NextResponse.redirect(authUrl);
+    setPendingOAuthCookie(response, { state, codeVerifier, redirectTo });
   }
 
-  const { codeVerifier, codeChallenge } = generatePKCEPair();
-  const state = generateState();
-  const authUrl = getAuthorizationUrl(codeChallenge, state, { redirectUri, prompt: fromLogout ? 'login' : undefined });
-  const response = NextResponse.redirect(authUrl);
-  setPendingOAuthCookie(response, { state, codeVerifier, redirectTo });
+  if (justLoggedOut) {
+    response.cookies.set('post-logout', '', { maxAge: 0, path: '/' });
+  }
   return response;
 }

--- a/app/api/integrations/camera/sso-session/route.ts
+++ b/app/api/integrations/camera/sso-session/route.ts
@@ -77,7 +77,9 @@ export async function POST(request: NextRequest) {
   }
 
   const response = NextResponse.json({ success: true, role: permission.role });
-  const minted = await mintMessmassSessionForSsoUser(ssoUser, permission, request, response);
+  const minted = await mintMessmassSessionForSsoUser(ssoUser, permission, request, response, {
+    access_token: accessToken,
+  });
   if (!minted) {
     return NextResponse.json({ success: false, error: 'no_access' }, { status: 403 });
   }

--- a/app/api/integrations/camera/sso-session/route.ts
+++ b/app/api/integrations/camera/sso-session/route.ts
@@ -53,6 +53,7 @@ export async function POST(request: NextRequest) {
   if (!accessToken) {
     return NextResponse.json({ success: false, error: 'accessToken is required' }, { status: 400 });
   }
+  const refreshToken = typeof body?.refreshToken === 'string' ? body.refreshToken.trim() : '';
 
   let ssoUser;
   try {
@@ -79,6 +80,7 @@ export async function POST(request: NextRequest) {
   const response = NextResponse.json({ success: true, role: permission.role });
   const minted = await mintMessmassSessionForSsoUser(ssoUser, permission, request, response, {
     access_token: accessToken,
+    refresh_token: refreshToken || undefined,
   });
   if (!minted) {
     return NextResponse.json({ success: false, error: 'no_access' }, { status: 403 });

--- a/components/TopHeader.tsx
+++ b/components/TopHeader.tsx
@@ -76,15 +76,17 @@ export default function TopHeader({ user }: TopHeaderProps) {
   };
   
   /* What: Handle logout action
-     Why: Clear session and redirect to login */
+     Why: Clear session (local + SSO tokens) and land on the real homepage --
+          not /admin/login, which immediately redirects back into SSO and
+          would make logout look like it did nothing. */
   const handleLogout = async () => {
     try {
       const response = await fetch('/api/admin/login', {
         method: 'DELETE',
       });
-      
+
       if (response.ok) {
-        router.push('/admin/login');
+        router.push('/');
       } else {
         window.alert('Logout failed. Please try again.');
       }

--- a/lib/auth/mintSession.ts
+++ b/lib/auth/mintSession.ts
@@ -26,6 +26,7 @@ import { FEATURE_FLAGS } from '@/lib/featureFlags';
 import config from '@/lib/config';
 
 const AUTH_SOURCE_COOKIE = 'auth-source';
+const SSO_TOKENS_COOKIE = 'sso-tokens';
 
 /** SSO app-role -> messmass's local role set. 'none' is handled via hasAppAccess() below. */
 function mapSsoRoleToMessmassRole(ssoRole: AppPermission['role']): UserRole {
@@ -45,11 +46,17 @@ export interface MintableSsoUser {
  * access -- caller decides how to handle that (redirect with an error, or
  * for the cross-app endpoint, a 403 JSON response).
  */
+export interface MintableSsoTokens {
+  access_token: string;
+  refresh_token?: string;
+}
+
 export async function mintMessmassSessionForSsoUser(
   ssoUser: MintableSsoUser,
   permission: AppPermission,
   request: NextRequest,
-  response: NextResponse
+  response: NextResponse,
+  ssoTokens?: MintableSsoTokens
 ): Promise<{ userId: string; role: UserRole } | null> {
   if (!hasAppAccess(permission)) return null;
 
@@ -113,6 +120,16 @@ export async function mintMessmassSessionForSsoUser(
   response.cookies.set(AUTH_SOURCE_COOKIE, 'sso', { ...cookieOpts, httpOnly: false });
   if (FEATURE_FLAGS.USE_JWT_SESSIONS) {
     response.cookies.set('session-format', 'jwt', { ...cookieOpts, httpOnly: false });
+  }
+  // WHAT: Keep the SSO access/refresh tokens around (httpOnly, never sent to
+  //     the client) so logout can revoke them at SSO instead of only
+  //     forgetting the local session.
+  // WHY: Without this, messmass had no way to end the SSO-side session at
+  //     all -- logging out only cleared messmass's own cookie while the SSO
+  //     tokens (and often SSO's own browser session) stayed live, so the
+  //     very next SSO redirect silently signed the user back in.
+  if (ssoTokens?.access_token) {
+    response.cookies.set(SSO_TOKENS_COOKIE, JSON.stringify(ssoTokens), cookieOpts);
   }
 
   return { userId, role: user.role };

--- a/lib/auth/mintSession.ts
+++ b/lib/auth/mintSession.ts
@@ -128,8 +128,19 @@ export async function mintMessmassSessionForSsoUser(
   //     all -- logging out only cleared messmass's own cookie while the SSO
   //     tokens (and often SSO's own browser session) stayed live, so the
   //     very next SSO redirect silently signed the user back in.
+  // SECURITY: deliberately host-only (no `domain` attribute), unlike the
+  //     other cookies above -- these are raw OAuth credentials only this
+  //     app's own logout endpoint needs, and the shared `.messmass.com`
+  //     domain would otherwise hand them to every sibling app's server on
+  //     every request.
   if (ssoTokens?.access_token) {
-    response.cookies.set(SSO_TOKENS_COOKIE, JSON.stringify(ssoTokens), cookieOpts);
+    response.cookies.set(SSO_TOKENS_COOKIE, JSON.stringify(ssoTokens), {
+      httpOnly: true,
+      secure: isProduction,
+      sameSite: 'lax',
+      maxAge: 7 * 24 * 60 * 60,
+      path: '/',
+    });
   }
 
   return { userId, role: user.role };

--- a/lib/auth/ssoOAuth.ts
+++ b/lib/auth/ssoOAuth.ts
@@ -228,6 +228,11 @@ export async function getUserInfo(accessToken: string): Promise<SSOUser> {
   };
 }
 
+// WHAT: Best-effort revocation, bounded to 3s.
+// WHY: This runs inline in the logout request (see app/api/admin/login's
+//     DELETE handler) -- an unresponsive SSO revoke endpoint must not be
+//     able to hang the whole logout request and leave the local session
+//     cookie un-cleared.
 export async function revokeToken(token: string, tokenTypeHint: 'access_token' | 'refresh_token' = 'access_token'): Promise<void> {
   const c = SSO_CONFIG();
   const endpoints = SSO_ENDPOINTS();
@@ -236,6 +241,7 @@ export async function revokeToken(token: string, tokenTypeHint: 'access_token' |
     method: 'POST',
     headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
     body: params.toString(),
+    signal: AbortSignal.timeout(3000),
   });
   if (!response.ok) {
     console.error('SSO token revocation failed:', response.status);


### PR DESCRIPTION
## Context

**Branch:** `feature/real-sso-logout`
**Base:** `main`
**Related:** follow-up to #310 (unified login UX) — that change made `/admin/login` auto-redirect straight to SSO whenever there was nothing to explain, which exposed a pre-existing gap: logout never actually ended the SSO-side session, so it could look like logout did nothing.

## Changes

**What changed:**
- `lib/auth/mintSession.ts` — optionally persists the SSO access/refresh tokens in a new httpOnly `sso-tokens` cookie at login time.
- `app/api/auth/sso/callback/route.ts`, `app/api/integrations/camera/sso-session/route.ts` — pass the SSO tokens through to `mintMessmassSessionForSsoUser` so they get stored.
- `app/api/admin/login/route.ts` (`DELETE`, i.e. logout) — revokes both tokens at SSO (best-effort, non-blocking) before clearing all local cookies, mirroring camera's existing logout behavior.
- `app/api/auth/sso/login/route.ts` — accepts `from_logout=true` and forwards `prompt=login` to SSO's authorize endpoint, so a login attempt shortly after logout shows SSO's real login screen instead of silently re-approving (mirrors camera's existing `from_logout` handling).
- `components/TopHeader.tsx` — the Logout button now lands on `/` instead of `/admin/login`, which (since #310) redirects straight back into SSO and would undo the logout instantly.

**Why:**
Logout only ever cleared messmass's own `admin-session` cookie. The SSO access/refresh tokens obtained at login were used once during the OAuth callback and then discarded — messmass had no way to revoke them, and SSO's own login session was never touched either way. So logging out and then hitting SSO again (directly, or via `/admin/login`'s new auto-redirect) silently re-authenticated the user, making logout look broken.

**How:**
Same pattern camera already uses for its own logout (`revokeToken()` against SSO's `/api/oauth/revoke`), extended to messmass, which previously had the `revokeToken()` function defined but never called. Landing on `/` (messmass's public homepage, ungated) instead of `/admin/login` avoids the new auto-redirect-to-SSO firing immediately after an intentional logout.

## Verification

**Manual Testing:**
- [x] Tested locally against a local OAuth test harness (fake SSO server): full login → confirmed `sso-tokens` cookie set with both tokens → logout → confirmed both tokens revoked at the IdP (verified the access token is dead afterward: a follow-up `userinfo` call with that same token returns 401) → confirmed messmass's own session is also gone (`/api/admin/auth` returns "Not authenticated").
- [x] Confirmed `from_logout=true` on `/api/auth/sso/login` correctly forwards `prompt=login` to SSO's authorize URL.
- [x] Confirmed via a real browser (Playwright): logging in, then clicking "Logout" in the admin panel, lands on `/` — no bounce-back to SSO or `/admin`.
- [x] No console errors introduced (one pre-existing, unrelated hydration warning present site-wide, not from this change).

**CI Status:**
- [x] Build succeeds (`npm run build`)
- [x] Type check passes (`npx tsc --noEmit`)
- [x] Lint passes (`npm run lint`, 0 warnings)

## Impact

**Breaking Changes:**
- [x] No breaking changes — logout's HTTP contract (`DELETE /api/admin/login` → `{ success: true }`) is unchanged; only its side effects (token revocation) and the client's post-logout navigation target changed.

**Security:**
- [x] Improves security posture — SSO tokens are now actually revoked on logout instead of remaining valid indefinitely after the local session ends.


---
_Generated by [Claude Code](https://claude.ai/code/session_01A4Mf2crWQydtCABm2ebETJ)_