### PR TITLE
Add guided tour (spotlight onboarding overlay) to the admin panel

### DIFF
--- a/components/AdminLayout.tsx
+++ b/components/AdminLayout.tsx
@@ -2,6 +2,7 @@
 
 import React from 'react';
 import { Box } from '@mantine/core';
+import { OverlayManagerProvider } from '@sovereignsquad/gds-core/client';
 import Sidebar from './Sidebar';
 import TopHeader from './TopHeader';
 import styles from './AdminLayout.module.css';
@@ -18,21 +19,26 @@ interface AdminLayoutProps {
 
 export default function AdminLayout({ children, user }: AdminLayoutProps) {
   const { isCollapsed } = useSidebar();
-  
+
   return (
-    <Box className={styles.adminLayout}>
-      <a href="#main-content" className={styles.skipToContent}>
-        Skip to main content
-      </a>
-      <Sidebar />
-      
-      <Box className={`${styles.mainWrapper} ${isCollapsed ? styles.collapsed : ''}`}>
-        <TopHeader user={user} />
-        
-        <Box component="main" id="main-content" className={`${styles.mainContent} content-surface`} tabIndex={-1}>
-          {children}
+    // WHAT: OverlayManagerProvider backs the guided-tour overlay stack (lib/tour/*)
+    // WHY: scoped to the admin layout, not the app-wide providers in app/providers.tsx,
+    //      since public report pages don't need overlay-manager machinery
+    <OverlayManagerProvider>
+      <Box className={styles.adminLayout}>
+        <a href="#main-content" className={styles.skipToContent}>
+          Skip to main content
+        </a>
+        <Sidebar />
+
+        <Box className={`${styles.mainWrapper} ${isCollapsed ? styles.collapsed : ''}`}>
+          <TopHeader user={user} />
+
+          <Box component="main" id="main-content" className={`${styles.mainContent} content-surface`} tabIndex={-1}>
+            {children}
+          </Box>
         </Box>
       </Box>
-    </Box>
+    </OverlayManagerProvider>
   );
 }

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -182,16 +182,16 @@ export default function Sidebar() {
             const navGroups = getSidebarNavGroups(visibleSection);
 
             return (
-              <div key={section.title} className={styles.navSection}>
+              <div key={section.title} className={styles.navSection} data-tour-id={`nav-section-${visibleSection.key}`}>
                 {!isCollapsed && (
                   <div className={styles.sectionTitle}>{section.title}</div>
                 )}
-                
+
                 <ul className={styles.navList}>
                   {navGroups.map((group) => {
                     const groupActive = isGroupActive(group.parent.path, group.children.map((child) => child.path));
                     return (
-                    <li key={group.parent.path} className={styles.navItem}>
+                    <li key={group.parent.path} className={styles.navItem} data-tour-id={`nav-${group.parent.path}`}>
                       <MantineNavLink
                         component={Link}
                         href={group.parent.path}
@@ -214,7 +214,7 @@ export default function Sidebar() {
                       {!isCollapsed && group.children.length > 0 && (
                         <ul className={styles.childList} aria-label={`${group.parent.label} submenu`}>
                           {group.children.map((child) => (
-                            <li key={child.path}>
+                            <li key={child.path} data-tour-id={`nav-${child.path}`}>
                               <MantineNavLink
                                 component={Link}
                                 href={child.path}

--- a/components/TopHeader.tsx
+++ b/components/TopHeader.tsx
@@ -5,6 +5,7 @@ import { useRouter } from 'next/navigation';
 import { ActionIcon, Avatar, Badge, Box, Button, Group, Paper, Stack, Text } from '@mantine/core';
 import { IconBell, IconDoorExit } from '@tabler/icons-react';
 import NotificationPanel from './NotificationPanel';
+import TourMenu from './tour/TourMenu';
 import styles from './TopHeader.module.css';
 
 /* What: Top header component for admin layout
@@ -106,6 +107,8 @@ export default function TopHeader({ user }: TopHeaderProps) {
         </Box>
         
         <Group className={styles.headerRight} gap="md" justify="flex-end" wrap="wrap">
+          <TourMenu />
+
           <div className={styles.notificationsBell}>
             <span
               id="notifications-live"

--- a/components/tour/TourMenu.module.css
+++ b/components/tour/TourMenu.module.css
@@ -1,0 +1,112 @@
+/* WHAT: Guided-tour entry point styles
+ * WHY: Mirrors NotificationPanel.module.css's dropdown pattern for visual
+ *      consistency with the existing header-icon-opens-a-panel convention. */
+
+.tourMenuWrapper {
+  position: relative;
+}
+
+.tourPanel {
+  position: absolute;
+  top: calc(100% + var(--mm-space-2));
+  right: 0;
+  width: 360px;
+  max-height: 520px;
+  background: var(--mm-white);
+  border: 1px solid var(--mm-border-color-default);
+  border-radius: var(--mm-radius-xl);
+  box-shadow: var(--mm-shadow-lg);
+  overflow: hidden;
+  z-index: calc(var(--z-sticky) + 2);
+  display: flex;
+  flex-direction: column;
+}
+
+.panelHeader {
+  padding: var(--mm-space-4) var(--mm-space-5);
+  border-bottom: 1px solid var(--mm-border-color-default);
+  background: var(--mm-gray-50);
+}
+
+.panelTitle {
+  font-size: var(--mm-font-size-base);
+  font-weight: var(--mm-font-weight-semibold);
+  color: var(--mm-gray-900);
+  margin: 0;
+}
+
+.tourList {
+  flex: 1;
+  overflow-y: auto;
+  overflow-x: hidden;
+}
+
+.tourItem {
+  display: block;
+  width: 100%;
+  text-align: left;
+  background: none;
+  border: none;
+  border-bottom: 1px solid var(--mm-border-color-light);
+  padding: var(--mm-space-3) var(--mm-space-5);
+  cursor: pointer;
+  transition: background var(--transition-base);
+}
+
+.tourItem:last-child {
+  border-bottom: none;
+}
+
+.tourItem:hover {
+  background: var(--mm-gray-50);
+}
+
+.tourItemHeader {
+  display: flex;
+  align-items: center;
+  gap: var(--mm-space-2);
+}
+
+.tourItemTitle {
+  font-size: var(--mm-font-size-sm);
+  font-weight: var(--mm-font-weight-semibold);
+  color: var(--mm-gray-900);
+}
+
+.tourItemCheck {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  border-radius: var(--mm-radius-full);
+  background: var(--mm-success);
+  color: var(--mm-white);
+}
+
+.tourItemDescription {
+  margin: var(--mm-space-1) 0 var(--mm-space-2) 0;
+  font-size: var(--mm-font-size-xs);
+  color: var(--mm-gray-600);
+  line-height: 1.4;
+}
+
+.tourItemAction {
+  font-size: var(--mm-font-size-xs);
+  font-weight: var(--mm-font-weight-medium);
+  color: var(--mm-color-primary-600);
+}
+
+.emptyState {
+  padding: var(--mm-space-8) var(--mm-space-5);
+  text-align: center;
+  color: var(--mm-gray-600);
+  font-size: var(--mm-font-size-sm);
+}
+
+@media (max-width: 480px) {
+  .tourPanel {
+    width: calc(100vw - var(--mm-space-8));
+    right: var(--mm-space-4);
+  }
+}

--- a/components/tour/TourMenu.tsx
+++ b/components/tour/TourMenu.tsx
@@ -18,6 +18,7 @@ import { useTourController, type TourController } from '@/lib/tour/useTourContro
 import { hasTourBeenSeen } from '@/lib/tour/storage';
 import { getWelcomeTourSteps } from '@/lib/tour/config/welcomeTourSteps';
 import { getSegmentTourSteps, getSegmentTourMeta } from '@/lib/tour/config/segmentTourSteps';
+import { useSidebar } from '@/contexts/SidebarContext';
 import type { UserRole } from '@/lib/users';
 
 interface TourEntry {
@@ -32,6 +33,7 @@ export default function TourMenu() {
   const [userRole, setUserRole] = useState<UserRole | undefined>(undefined);
   const [loadingRole, setLoadingRole] = useState(true);
   const panelRef = useRef<HTMLDivElement>(null);
+  const { isCollapsed, setIsCollapsed } = useSidebar();
 
   useEffect(() => {
     const fetchUserRole = async () => {
@@ -123,6 +125,12 @@ export default function TourMenu() {
 
   const startTour = (controller: TourController) => {
     setIsOpen(false);
+    // WHAT: expand the sidebar before starting -- WHY: Sidebar.tsx doesn't
+    // render child nav <li>s (and their data-tour-id) at all while
+    // collapsed, so a segment tour with child steps (Reports, Analytics)
+    // would silently retry-then-skip nearly every step for a returning
+    // user with the sidebar collapsed.
+    if (isCollapsed) setIsCollapsed(false);
     controller.start();
   };
 

--- a/components/tour/TourMenu.tsx
+++ b/components/tour/TourMenu.tsx
@@ -1,0 +1,193 @@
+'use client';
+
+/* WHAT: Header entry point for the guided tour system -- a bell-style
+ *       ActionIcon that opens a dropdown listing the welcome tour and all
+ *       six segment tours.
+ * WHY: Trigger model is fully manual (no auto-start) -- this is the one
+ *      persistent, discoverable way to start or replay any tour. Structured
+ *      like NotificationPanel.tsx (outside-click-to-close, Escape-to-close,
+ *      focus-on-open) for consistency with the app's existing header-icon
+ *      dropdown pattern. */
+
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import { ActionIcon } from '@mantine/core';
+import { IconCheck, IconHelpCircle } from '@tabler/icons-react';
+import styles from './TourMenu.module.css';
+import TourOverlay from './TourOverlay';
+import { useTourController, type TourController } from '@/lib/tour/useTourController';
+import { hasTourBeenSeen } from '@/lib/tour/storage';
+import { getWelcomeTourSteps } from '@/lib/tour/config/welcomeTourSteps';
+import { getSegmentTourSteps, getSegmentTourMeta } from '@/lib/tour/config/segmentTourSteps';
+import type { UserRole } from '@/lib/users';
+
+interface TourEntry {
+  tourId: string;
+  title: string;
+  description: string;
+  controller: TourController;
+}
+
+export default function TourMenu() {
+  const [isOpen, setIsOpen] = useState(false);
+  const [userRole, setUserRole] = useState<UserRole | undefined>(undefined);
+  const [loadingRole, setLoadingRole] = useState(true);
+  const panelRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const fetchUserRole = async () => {
+      try {
+        const response = await fetch('/api/admin/auth', { cache: 'no-store' });
+        if (response.ok) {
+          const data = await response.json();
+          if (data.user?.role) {
+            setUserRole(data.user.role as UserRole);
+          }
+        }
+      } catch (error) {
+        console.error('Failed to fetch user role:', error);
+      } finally {
+        setLoadingRole(false);
+      }
+    };
+
+    fetchUserRole();
+  }, []);
+
+  // WHAT: Close on outside click. WHY: standard dropdown UX, matches NotificationPanel.
+  useEffect(() => {
+    function handleClickOutside(event: MouseEvent) {
+      if (panelRef.current && !panelRef.current.contains(event.target as Node)) {
+        setIsOpen(false);
+      }
+    }
+    if (isOpen) {
+      document.addEventListener('mousedown', handleClickOutside);
+      return () => document.removeEventListener('mousedown', handleClickOutside);
+    }
+  }, [isOpen]);
+
+  // WHAT: Escape-to-close + focus the panel on open.
+  useEffect(() => {
+    if (!isOpen) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setIsOpen(false);
+    };
+    document.addEventListener('keydown', onKey);
+    panelRef.current?.focus();
+    return () => document.removeEventListener('keydown', onKey);
+  }, [isOpen]);
+
+  const segmentMeta = useMemo(() => getSegmentTourMeta(), []);
+
+  const welcomeSteps = useMemo(() => getWelcomeTourSteps(userRole), [userRole]);
+  const operationsSteps = useMemo(() => getSegmentTourSteps('operations', userRole), [userRole]);
+  const entitiesSteps = useMemo(() => getSegmentTourSteps('entities', userRole), [userRole]);
+  const reportsSteps = useMemo(() => getSegmentTourSteps('reports', userRole), [userRole]);
+  const dataSteps = useMemo(() => getSegmentTourSteps('data', userRole), [userRole]);
+  const analyticsSteps = useMemo(() => getSegmentTourSteps('analytics', userRole), [userRole]);
+  const systemSteps = useMemo(() => getSegmentTourSteps('system', userRole), [userRole]);
+
+  const welcomeController = useTourController('welcome', welcomeSteps);
+  const operationsController = useTourController('operations', operationsSteps);
+  const entitiesController = useTourController('entities', entitiesSteps);
+  const reportsController = useTourController('reports', reportsSteps);
+  const dataController = useTourController('data', dataSteps);
+  const analyticsController = useTourController('analytics', analyticsSteps);
+  const systemController = useTourController('system', systemSteps);
+
+  const segmentControllers: Record<string, TourController> = {
+    operations: operationsController,
+    entities: entitiesController,
+    reports: reportsController,
+    data: dataController,
+    analytics: analyticsController,
+    system: systemController,
+  };
+
+  const entries: TourEntry[] = [
+    {
+      tourId: 'welcome',
+      title: 'Welcome tour',
+      description: 'A quick look at the six areas of the admin panel.',
+      controller: welcomeController,
+    },
+    ...segmentMeta.map((section) => ({
+      tourId: section.key,
+      title: section.title,
+      description: section.description,
+      controller: segmentControllers[section.key],
+    })),
+    // Hide any tour that would have zero accessible steps for the current
+    // role, rather than showing it disabled.
+  ].filter((entry) => entry.controller.totalSteps > 0);
+
+  const startTour = (controller: TourController) => {
+    setIsOpen(false);
+    controller.start();
+  };
+
+  return (
+    <>
+      <div className={styles.tourMenuWrapper}>
+        <ActionIcon
+          variant="default"
+          size="lg"
+          radius="md"
+          color="gray"
+          onClick={() => setIsOpen((prev) => !prev)}
+          title="Guided tours"
+          aria-label="Guided tours"
+          aria-expanded={isOpen}
+        >
+          <IconHelpCircle size={18} stroke={1.8} />
+        </ActionIcon>
+
+        {isOpen && (
+          <div ref={panelRef} className={styles.tourPanel} role="dialog" aria-label="Guided tours" tabIndex={-1}>
+            <div className={styles.panelHeader}>
+              <h3 className={styles.panelTitle}>Guided tours</h3>
+            </div>
+            <div className={styles.tourList}>
+              {loadingRole ? (
+                <div className={styles.emptyState}>
+                  <p>Loading…</p>
+                </div>
+              ) : (
+                entries.map((entry) => {
+                  const seen = hasTourBeenSeen(entry.tourId);
+                  return (
+                    <button
+                      key={entry.tourId}
+                      type="button"
+                      className={styles.tourItem}
+                      onClick={() => startTour(entry.controller)}
+                    >
+                      <div className={styles.tourItemHeader}>
+                        <span className={styles.tourItemTitle}>{entry.title}</span>
+                        {seen && (
+                          <span className={styles.tourItemCheck} aria-label="Completed">
+                            <IconCheck size={14} stroke={2} />
+                          </span>
+                        )}
+                      </div>
+                      <p className={styles.tourItemDescription}>{entry.description}</p>
+                      <span className={styles.tourItemAction}>{seen ? 'Replay' : 'Start'}</span>
+                    </button>
+                  );
+                })
+              )}
+            </div>
+          </div>
+        )}
+      </div>
+
+      <TourOverlay controller={welcomeController} />
+      <TourOverlay controller={operationsController} />
+      <TourOverlay controller={entitiesController} />
+      <TourOverlay controller={reportsController} />
+      <TourOverlay controller={dataController} />
+      <TourOverlay controller={analyticsController} />
+      <TourOverlay controller={systemController} />
+    </>
+  );
+}

--- a/components/tour/TourOverlay.module.css
+++ b/components/tour/TourOverlay.module.css
@@ -1,0 +1,22 @@
+/*
+ * WHAT: the guided tour's dark backdrop / spotlight-cutout color values.
+ * WHY: kept in a CSS file rather than inline in TourOverlay.tsx, matching
+ *      this app's own convention of keeping raw color literals out of
+ *      canonical .tsx surfaces (see scripts/check-design-violations.js).
+ */
+
+.backdropFallback {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 15, 20, 0.65);
+}
+
+.spotlight {
+  position: fixed;
+  pointer-events: none;
+  box-shadow: 0 0 0 9999px rgba(15, 15, 20, 0.65);
+}
+
+.spotlightAnimated {
+  transition: top 200ms ease, left 200ms ease, width 200ms ease, height 200ms ease;
+}

--- a/components/tour/TourOverlay.tsx
+++ b/components/tour/TourOverlay.tsx
@@ -160,10 +160,15 @@ export default function TourOverlay({ controller }: { controller: TourController
 
   return (
     <>
-      {/* WHAT: toggles pointer-events based on whether a spotlight rect exists
-          WHY: only a runtime-computed boolean, can't be a static CSS class */}
+      {/* WHAT: always intercepts pointer events (a real modal backdrop)
+          WHY: the tour registers with closeOnOutsideClick: false -- letting
+               clicks pass through to the page (e.g. sidebar links) while a
+               step is open would let a user navigate away while the tour
+               logically stays "open", and z-index uses the shared popover
+               token so this renders above fixed chrome (sidebar/header,
+               which use --z-fixed/--z-sticky, both lower) */}
       {/* eslint-disable-next-line react/forbid-dom-props */}
-      <div aria-hidden style={{ position: 'fixed', inset: 0, zIndex: 1000, pointerEvents: rect ? 'none' : 'auto' }}>
+      <div aria-hidden style={{ position: 'fixed', inset: 0, zIndex: 'var(--z-popover)', pointerEvents: 'auto' }}>
         {rect ? (
           <div
             className={reducedMotion ? styles.spotlight : `${styles.spotlight} ${styles.spotlightAnimated}`}
@@ -192,9 +197,12 @@ export default function TourOverlay({ controller }: { controller: TourController
         tabIndex={-1}
         onKeyDown={handleKeyDown}
         // WHAT: positions the tooltip relative to the live-measured spotlight rect
-        // WHY: computed by tooltipPosition() at runtime, can't be a static CSS class
+        // WHY: computed by tooltipPosition() at runtime, can't be a static CSS class.
+        //      z-index uses the shared tooltip token, one level above the
+        //      backdrop's popover token, so it always paints above both the
+        //      backdrop and fixed admin chrome.
         // eslint-disable-next-line react/forbid-dom-props
-        style={{ position: 'fixed', zIndex: 1001, width: 320, maxWidth: 'calc(100vw - 24px)', ...tooltipPosition(rect) }}
+        style={{ position: 'fixed', zIndex: 'var(--z-tooltip)', width: 320, maxWidth: 'calc(100vw - 24px)', ...tooltipPosition(rect) }}
       >
         <Box p="md" style={{ background: 'var(--mantine-color-body)', borderRadius: 12, boxShadow: 'var(--mantine-shadow-lg)' }}>
           <Stack gap="sm">

--- a/components/tour/TourOverlay.tsx
+++ b/components/tour/TourOverlay.tsx
@@ -1,0 +1,233 @@
+'use client';
+
+import { useLayoutEffect, useRef, useState, type CSSProperties, type KeyboardEvent as ReactKeyboardEvent } from 'react';
+import { Box, Button, Group, Stack, Text } from '@mantine/core';
+import type { TourController } from '@/lib/tour/useTourController';
+import styles from './TourOverlay.module.css';
+
+interface TargetRect {
+  top: number;
+  left: number;
+  width: number;
+  height: number;
+  radius: string;
+}
+
+function measureTarget(selector: string): TargetRect | null {
+  const el = document.querySelector<HTMLElement>(selector);
+  if (!el) return null;
+  const rect = el.getBoundingClientRect();
+  if (rect.width === 0 && rect.height === 0) return null;
+  const radius = window.getComputedStyle(el).borderRadius || '8px';
+  return { top: rect.top, left: rect.left, width: rect.width, height: rect.height, radius };
+}
+
+function prefersReducedMotion(): boolean {
+  return typeof window !== 'undefined' && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+}
+
+/** Places the tooltip below the spotlighted rect when there's room, else above; clamps horizontally to the viewport. */
+function tooltipPosition(rect: TargetRect | null): CSSProperties {
+  if (!rect || typeof window === 'undefined') {
+    return { top: '50%', left: '50%', transform: 'translate(-50%, -50%)' };
+  }
+  const margin = 12;
+  const tooltipWidth = 320;
+  const viewportHeight = window.innerHeight;
+  const viewportWidth = window.innerWidth;
+  const spaceBelow = viewportHeight - (rect.top + rect.height);
+  const preferBelow = spaceBelow >= 160 || spaceBelow >= rect.top;
+
+  const left = Math.min(Math.max(margin, rect.left), Math.max(margin, viewportWidth - tooltipWidth - margin));
+
+  return preferBelow
+    ? { top: rect.top + rect.height + margin, left }
+    : { bottom: viewportHeight - rect.top + margin, left };
+}
+
+/**
+ * Backdrop + spotlight cutout + positioned tooltip for one active guided
+ * tour. Purely presentational -- all step state lives in `controller`
+ * (lib/tour/useTourController.ts).
+ */
+export default function TourOverlay({ controller }: { controller: TourController }) {
+  const { isOpen, isTopMost, currentStep, currentIndex, totalSteps, next, back, skip } = controller;
+  const [rect, setRect] = useState<TargetRect | null>(null);
+  // True while polling for a target that hasn't mounted yet -- kept separate
+  // from `rect` so a not-yet-mounted target renders nothing rather than a
+  // misleading centered dialog that then jumps to the spotlight once found.
+  const [measuring, setMeasuring] = useState(true);
+  const tooltipRef = useRef<HTMLDivElement>(null);
+  const previouslyFocusedRef = useRef<HTMLElement | null>(null);
+
+  useLayoutEffect(() => {
+    if (!isOpen || !currentStep) {
+      setRect(null);
+      setMeasuring(true);
+      return;
+    }
+
+    setMeasuring(true);
+    let cancelled = false;
+    let attempts = 0;
+    let retryTimer = 0;
+    let resizeObserver: ResizeObserver | null = null;
+    const measure = () => setRect(measureTarget(currentStep.targetSelector));
+
+    // A role-filtered step's target should always be in the DOM once the
+    // sidebar has rendered, but poll briefly anyway before concluding it
+    // genuinely won't appear -- cheap safety net, matches the tour engine
+    // this was ported from.
+    const MAX_ATTEMPTS = 20;
+    const RETRY_MS = 150;
+
+    const tryMeasure = () => {
+      if (cancelled) return;
+      const target = document.querySelector<HTMLElement>(currentStep.targetSelector);
+      if (!target) {
+        attempts += 1;
+        if (attempts >= MAX_ATTEMPTS) {
+          console.error(`[GuidedTour] target not found for step "${currentStep.id}": ${currentStep.targetSelector}`);
+          next();
+          return;
+        }
+        retryTimer = window.setTimeout(tryMeasure, RETRY_MS);
+        return;
+      }
+
+      setMeasuring(false);
+      target.scrollIntoView({ block: 'center', behavior: prefersReducedMotion() ? 'auto' : 'smooth' });
+      measure();
+
+      resizeObserver = new ResizeObserver(measure);
+      resizeObserver.observe(target);
+      window.addEventListener('resize', measure, { passive: true });
+      window.addEventListener('scroll', measure, { passive: true, capture: true });
+    };
+
+    tryMeasure();
+
+    return () => {
+      cancelled = true;
+      if (retryTimer) window.clearTimeout(retryTimer);
+      resizeObserver?.disconnect();
+      window.removeEventListener('resize', measure);
+      window.removeEventListener('scroll', measure, true);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isOpen, currentStep?.id]);
+
+  useLayoutEffect(() => {
+    if (!isOpen || !currentStep || measuring) return;
+    previouslyFocusedRef.current = document.activeElement as HTMLElement | null;
+    tooltipRef.current?.focus();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isOpen, currentStep?.id, measuring]);
+
+  useLayoutEffect(() => {
+    if (isOpen || !previouslyFocusedRef.current) return;
+    previouslyFocusedRef.current.focus?.();
+    previouslyFocusedRef.current = null;
+  }, [isOpen]);
+
+  const handleKeyDown = (event: ReactKeyboardEvent<HTMLDivElement>) => {
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      skip();
+      return;
+    }
+    if (event.key === 'Tab') {
+      const container = tooltipRef.current;
+      if (!container) return;
+      const focusable = container.querySelectorAll<HTMLElement>('button, [href], [tabindex]:not([tabindex="-1"])');
+      if (focusable.length === 0) return;
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      if (event.shiftKey && document.activeElement === first) {
+        event.preventDefault();
+        last.focus();
+      } else if (!event.shiftKey && document.activeElement === last) {
+        event.preventDefault();
+        first.focus();
+      }
+    }
+  };
+
+  if (!isOpen || !currentStep || !isTopMost || measuring) return null;
+
+  const isLastStep = currentIndex + 1 >= totalSteps;
+  const reducedMotion = prefersReducedMotion();
+
+  return (
+    <>
+      {/* WHAT: toggles pointer-events based on whether a spotlight rect exists
+          WHY: only a runtime-computed boolean, can't be a static CSS class */}
+      {/* eslint-disable-next-line react/forbid-dom-props */}
+      <div aria-hidden style={{ position: 'fixed', inset: 0, zIndex: 1000, pointerEvents: rect ? 'none' : 'auto' }}>
+        {rect ? (
+          <div
+            className={reducedMotion ? styles.spotlight : `${styles.spotlight} ${styles.spotlightAnimated}`}
+            // WHAT: positions the spotlight cutout over the live-measured target
+            // WHY: top/left/width/height/radius come from getBoundingClientRect()
+            //      at runtime -- inherently can't be a static CSS class
+            // eslint-disable-next-line react/forbid-dom-props
+            style={{
+              top: rect.top,
+              left: rect.left,
+              width: rect.width,
+              height: rect.height,
+              borderRadius: rect.radius,
+            }}
+          />
+        ) : (
+          <div className={styles.backdropFallback} />
+        )}
+      </div>
+      <div
+        ref={tooltipRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="guided-tour-step-title"
+        aria-describedby="guided-tour-step-description"
+        tabIndex={-1}
+        onKeyDown={handleKeyDown}
+        // WHAT: positions the tooltip relative to the live-measured spotlight rect
+        // WHY: computed by tooltipPosition() at runtime, can't be a static CSS class
+        // eslint-disable-next-line react/forbid-dom-props
+        style={{ position: 'fixed', zIndex: 1001, width: 320, maxWidth: 'calc(100vw - 24px)', ...tooltipPosition(rect) }}
+      >
+        <Box p="md" style={{ background: 'var(--mantine-color-body)', borderRadius: 12, boxShadow: 'var(--mantine-shadow-lg)' }}>
+          <Stack gap="sm">
+            <Text id="guided-tour-step-title" fw={700}>
+              {currentStep.title}
+            </Text>
+            <Text id="guided-tour-step-description" size="sm" c="dimmed">
+              {currentStep.description}
+            </Text>
+            <Text size="xs" c="dimmed">
+              Step {currentIndex + 1} of {totalSteps}
+            </Text>
+            <Group justify="space-between">
+              <Button variant="subtle" size="xs" onClick={skip}>
+                Skip
+              </Button>
+              <Group gap="xs">
+                {currentIndex > 0 ? (
+                  <Button variant="default" size="xs" onClick={back}>
+                    Back
+                  </Button>
+                ) : null}
+                <Button size="xs" onClick={next}>
+                  {isLastStep ? 'Done' : 'Next'}
+                </Button>
+              </Group>
+            </Group>
+          </Stack>
+        </Box>
+      </div>
+      <div aria-live="polite" className="sr-only">
+        {`Step ${currentIndex + 1} of ${totalSteps}: ${typeof currentStep.title === 'string' ? currentStep.title : ''}`}
+      </div>
+    </>
+  );
+}

--- a/docs/_meta/meta-docs-consistency-audit.md
+++ b/docs/_meta/meta-docs-consistency-audit.md
@@ -1,10 +1,10 @@
 # Docs Consistency Audit
 Status: Active
-Last Updated: 2026-07-20T19:36:58.803Z
+Last Updated: 2026-08-04T22:03:00.203Z
 Canonical: Yes
 Owner: Documentation
 
-Package version: 12.1.37
+Package version: 12.1.38
 Current docs scanned: 134
 Failures: 0
 

--- a/docs/_meta/meta-docs-link-check.md
+++ b/docs/_meta/meta-docs-link-check.md
@@ -1,6 +1,6 @@
 # Docs Link Check
 Status: Active
-Last Updated: 2026-07-20T19:36:58Z
+Last Updated: 2026-08-04T22:03:00Z
 Canonical: Yes
 Owner: Documentation
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -4,7 +4,7 @@ Last Updated: 2026-06-25
 Canonical: No
 Owner: Architecture
 
-Version: 12.1.37
+Version: 12.1.38
 
 **Mantine Entity, Variant, and Public Report Shell Delivery (2026-06-25):**
 - **Report variant selector recovery:** Mantine `Select` dropdowns inside report variant `FormModal` now render through a portal with modal-safe z-index, preventing the dropdown from being hidden behind or interpreted as outside the dialog.
@@ -2052,6 +2052,54 @@ See `docs/operations/operations-roadmap.md` for planned improvements:
 5. Implement focus trap in mobile overlay (Low priority)
 
 For complete documentation, usage examples, troubleshooting, and technical details, see [ADMIN_LAYOUT_SYSTEM (archived)](archive/_archive/deprecated-guides-2025/archive-legacy-guides-pack.md#legacy-admin_layout_system).
+
+---
+
+## Guided Tour System (Version 12.1.38)
+
+### Overview
+
+A manually-triggered spotlight/backdrop product tour for the admin panel — a dark backdrop with a cutout highlighting one nav item at a time, plus a step-by-step tooltip. No auto-start: a "Guided tours" entry point in `TopHeader.tsx` opens a menu offering a short welcome tour (introduces the six sidebar sections) and one tour per section (Operations, Entities, Reports, Data, Analytics, System). No equivalent existed anywhere in this codebase or its dependencies before this — see `components/tour/`, `lib/tour/`.
+
+### Key Components
+
+#### 1. `useTourController` (`lib/tour/useTourController.ts`)
+- **Role**: Step-sequencing state (`start`/`next`/`back`/`skip`) for one tour
+- **Integration**: Registers with `@sovereignsquad/gds-core`'s `OverlayManagerProvider` as a `popover` overlay, so a tour yields correctly to the notification panel or any other overlay instead of running its own independent stack
+- **Note**: `next()` reads `currentIndex` from the hook's closure rather than a `setCurrentIndex` functional updater — the alternative called a side-effecting `finish()` (mutating a *different* component's overlay state) from inside a value React can invoke during another component's render pass, which is unsafe
+
+#### 2. `TourOverlay` (`components/tour/TourOverlay.tsx`)
+- **Role**: Presentational spotlight/backdrop/tooltip renderer, purely driven by a `TourController`
+- **Measurement**: `getBoundingClientRect()` against `[data-tour-id="..."]`, tracked live via `ResizeObserver` + `resize`/`scroll` listeners
+- **Retry**: polls briefly (~3s) for a target that hasn't mounted yet before concluding it genuinely won't appear and auto-skipping the step — tracked via a separate `measuring` boolean so a not-yet-mounted target renders nothing rather than a misleading centered dialog
+
+#### 3. `TourMenu` (`components/tour/TourMenu.tsx`)
+- **Role**: The "Guided tours" entry point — an `ActionIcon` + dropdown panel in `TopHeader.tsx`, structured like the existing `NotificationPanel.tsx` (outside-click-to-close, Escape-to-close, focus-on-open) for consistency with that already-proven pattern
+- **Role filtering**: fetches the current user's role via `/api/admin/auth` (same call `Sidebar.tsx` already makes) and hides any tour with zero accessible items for that role, via `canAccessMenuItem` (`lib/permissions.ts`)
+- **Ownership**: mounts all seven `useTourController` instances (welcome + 6 segments) and their `TourOverlay`s; none auto-start
+
+#### 4. Step content (`lib/tour/config/segmentTourSteps.ts`, `welcomeTourSteps.ts`)
+- Segment tour steps are **derived** from `lib/adminNavigation.ts`'s `adminNavSections` — each nav item's existing `label`/`description` (already authored, shown as hover text) becomes the step's title/description, so tour copy and nav copy can't drift apart
+- `AdminNavItem` gained an optional `tourDescription?: string` field, used only where the existing `description` assumed knowledge a first-time reader wouldn't have (e.g. "KYC Variables", "Clicker Sets", "Reporting Workspace") — `description` remains the fallback and the default for every item where it already reads fine standalone
+- The welcome tour targets `data-tour-id="nav-section-<key>"` (one per sidebar section) and drops any section with zero accessible items for the current role, since `Sidebar.tsx` itself doesn't render that section's wrapper when nothing inside it is visible
+
+### `data-tour-id` convention
+
+The only DOM-targeting-attribute convention in this codebase so far (no prior `data-testid`/`data-tour-id` existed anywhere). Added directly to `components/Sidebar.tsx`'s existing nav `<li>` elements and section wrapper `<div>`s:
+- `data-tour-id="nav-<path>"` on each nav item (parent and child)
+- `data-tour-id="nav-section-<key>"` on each section wrapper
+
+### Persistence
+
+`lib/tour/storage.ts` — plain exported functions (`hasTourBeenSeen`/`markTourSeen`), SSR-guarded, try/catch, mirroring `lib/adminViewState.ts`'s existing style rather than introducing a new persistence pattern. `localStorage` keys: `mm-tour-<tourId>`.
+
+### Provider scope
+
+`OverlayManagerProvider` is mounted in `components/AdminLayout.tsx`, not the app-wide `app/providers.tsx` — deliberately scoped to the admin layout only, since public report pages (`/report/[slug]`, etc.) share the root providers and have no need for overlay-manager machinery.
+
+### Accessibility
+
+`role="dialog"` `aria-modal="true"` tooltip, manual Tab focus-trap, `Escape` to skip, `aria-live="polite"` step announcements, `prefers-reduced-motion` disables the spotlight-move transition, focus returns to the triggering element on exit.
 
 ---
 

--- a/docs/components/components-reusable-components-inventory.md
+++ b/docs/components/components-reusable-components-inventory.md
@@ -4,7 +4,7 @@ Last Updated: 2026-04-24
 Canonical: No
 Owner: Architecture
 
-**Version**: 12.1.37
+**Version**: 12.1.38
 **Last Updated**: 2026-04-24 (UTC)
 **Purpose**: Complete catalog of all reusable components, modules, styling systems, and utilities
 

--- a/docs/components/components-unified-input-system.md
+++ b/docs/components/components-unified-input-system.md
@@ -4,7 +4,7 @@ Last Updated: 2026-01-11T22:28:38.000Z
 Canonical: No
 Owner: Architecture
 
-**Version**: 12.1.37
+**Version**: 12.1.38
 **Last Updated**: 2026-01-11T22:28:38.000Z
 **Status**: Production-Ready
 

--- a/docs/design/design-system.md
+++ b/docs/design/design-system.md
@@ -4,7 +4,7 @@ Last Updated: 2026-06-26T10:00:00.000Z
 Canonical: Yes
 Owner: Architecture
 
-**Version**: 12.1.37
+**Version**: 12.1.38
 **Status**: Production
 
 ## Purpose

--- a/docs/guides/guides-form-input-migration-guide.md
+++ b/docs/guides/guides-form-input-migration-guide.md
@@ -4,7 +4,7 @@ Last Updated: 2026-01-11T22:28:38.000Z
 Canonical: No
 Owner: Product
 
-**Version**: 12.1.37
+**Version**: 12.1.38
 **Last Updated**: 2026-01-11T22:28:38.000Z
 **Purpose**: Prevent aggressive parsing anti-patterns in future forms
 

--- a/docs/guides/guides-input-system-complete.md
+++ b/docs/guides/guides-input-system-complete.md
@@ -5,7 +5,7 @@ Canonical: No
 Owner: Product
 
 **Date**: 2025-12-25T20:50:00.000Z
-**Version**: 12.1.37
+**Version**: 12.1.38
 **Status**: ✅ Complete - Production Ready
 
 ## 📋 Overview

--- a/docs/low-level-design.md
+++ b/docs/low-level-design.md
@@ -4,7 +4,7 @@ Last Updated: 2026-06-25T00:00:00.000Z
 Canonical: No
 Owner: Architecture
 
-Version: 12.1.37
+Version: 12.1.38
 
 This document captures implementation-level contracts for recently changed high-risk flows. It complements `docs/architecture.md`; it does not replace feature specs or API references.
 

--- a/docs/operations/operations-release-notes.md
+++ b/docs/operations/operations-release-notes.md
@@ -1,8 +1,25 @@
 # {messmass} Release Notes
 Status: Active
-Last Updated: 2026-07-20T19:36:17.000Z
+Last Updated: 2026-08-04T21:59:31.000Z
 Canonical: No
 Owner: Operations
+
+## [v12.1.38] — 2026-08-04T21:59:31.000Z
+
+### Summary
+Added a guided tour (spotlight onboarding overlay) to the admin panel — a manually-triggered "Guided tours" entry point in the header, offering a short welcome tour plus one tour per sidebar section (Operations, Entities, Reports, Data, Analytics, System), so a new admin can get "what is an event / report / partner" explained in place, pointing at the actual nav item.
+
+### What Was Delivered
+- New tour engine (`lib/tour/*`, `components/tour/*`): a from-scratch spotlight/backdrop overlay (no existing library covers this), registered with `@sovereignsquad/gds-core`'s `OverlayManagerProvider` (newly mounted, scoped to the admin layout only) so it coordinates with the notification panel instead of running an independent overlay stack.
+- `components/tour/TourMenu.tsx` — the entry point, structured like the existing `NotificationPanel.tsx` (outside-click-to-close, Escape-to-close, focus-on-open). Lists the welcome tour and all six segment tours, hides any tour with zero accessible items for the current role, and shows a completed checkmark per tour via `localStorage`.
+- Tour step copy is derived from `lib/adminNavigation.ts`'s existing per-item `label`/`description` fields (already authored, shown as nav hover text) rather than re-written from scratch, keeping one source of truth. A new optional `tourDescription` field overrides the nav description only where it assumed prior knowledge a first-time reader wouldn't have (e.g. "KYC Variables", "Clicker Sets", "Reporting Workspace").
+- New `data-tour-id` convention on `components/Sidebar.tsx`'s nav items and section wrappers — the only DOM targeting attribute convention in the codebase so far.
+
+### Testing
+- `type-check` and `lint` clean across all new/changed files.
+- Live-verified the tour engine (spotlight measurement, retry-then-skip for a not-yet-mounted target, Tab focus-trap, Next/Back/Skip/Done, keyboard Escape, `localStorage` persistence) in a real browser against a temporary scratch route that mounts the engine directly, bypassing the admin auth/DB chain entirely — this sandbox cannot reach messmass's MongoDB Atlas cluster (confirmed independently; even the public homepage's own DB-backed data fetch 500s here), so no route requiring a real authenticated session could be exercised end-to-end. The scratch route was deleted before this commit.
+- Role-based step filtering (`getSegmentTourSteps`, `getWelcomeTourSteps`) verified directly against `guest`/`user`/`admin`/`superadmin` roles — confirmed each role sees exactly the nav items `canAccessMenuItem` already grants it.
+- Full Sidebar/TopHeader/TourMenu integration under a real logged-in session was **not** live-verified, for the DB-connectivity reason above.
 
 ## [v12.1.37] — 2026-07-20T19:36:17.000Z
 

--- a/lib/adminNavigation.ts
+++ b/lib/adminNavigation.ts
@@ -6,6 +6,14 @@ export interface AdminNavItem {
   description: string;
   accentColor: string;
   showInAdminWorkspace?: boolean;
+  /**
+   * WHAT: alternate copy for the guided tour (lib/tour/*)
+   * WHY: `description` is nav-item hover text, written for someone who
+   *      already knows roughly what the item is. Set this only where that
+   *      assumption doesn't hold for a first-time reader; otherwise the
+   *      tour falls back to `description` as the single source of truth.
+   */
+  tourDescription?: string;
 }
 
 export interface AdminNavSection {
@@ -42,6 +50,7 @@ export const adminNavSections: AdminNavSection[] = [
         path: '/admin/events',
         icon: 'event',
         description: 'Create events, manage setup, and open live editor or report flows.',
+        tourDescription: 'An event is a single occurrence you track stats for — a game, an activation, a campaign moment. It belongs to a partner, and its tracked stats become its report.',
         accentColor: navAccent.success,
       },
       {
@@ -49,6 +58,7 @@ export const adminNavSections: AdminNavSection[] = [
         path: '/admin/analytics/sponsorship/activation',
         icon: 'task_alt',
         description: 'Work sponsor proof gaps, recap readiness, and delivery follow-up queues.',
+        tourDescription: 'Track what each sponsor still needs before their activation is complete — missing proof, recap status, and follow-up tasks.',
         accentColor: navAccent.warning,
       },
       {
@@ -105,6 +115,7 @@ export const adminNavSections: AdminNavSection[] = [
         path: '/admin/reports',
         icon: 'dashboard_customize',
         description: 'Enter the canonical reporting workspace and choose the setup surface you need.',
+        tourDescription: 'A report is the shareable page a partner sees for their event or organization. This is the hub for everything that builds one — layout, visual theme, and reusable content.',
         accentColor: navAccent.primary,
       },
       {
@@ -112,6 +123,7 @@ export const adminNavSections: AdminNavSection[] = [
         path: '/admin/visualization',
         icon: 'view_quilt',
         description: 'Manage report blocks, layouts, preview flow, and template composition.',
+        tourDescription: 'Design what a report looks like — arrange its blocks (charts, stats, text) into a layout, then preview it before it goes live.',
         accentColor: navAccent.secondary,
         showInAdminWorkspace: false,
       },
@@ -151,6 +163,7 @@ export const adminNavSections: AdminNavSection[] = [
         path: '/admin/kyc',
         icon: 'lock',
         description: 'Manage tracked variables, aliases, and input-field definitions.',
+        tourDescription: 'The master dictionary of every metric messmass can track — VIP guests, merch sold, and so on. Define a variable once here, and it becomes usable in data entry and report formulas.',
         accentColor: navAccent.primary,
       },
       {
@@ -158,6 +171,7 @@ export const adminNavSections: AdminNavSection[] = [
         path: '/admin/clicker-manager',
         icon: 'swap_horiz',
         description: 'Manage clicker-mode groupings and partner-level variable-set assignment.',
+        tourDescription: 'A Clicker Set is a reusable layout for fast, tap-to-count data entry at live events. Assign a set to a partner and every one of their events uses that same counter layout.',
         accentColor: navAccent.secondary,
       },
       {
@@ -200,6 +214,7 @@ export const adminNavSections: AdminNavSection[] = [
         path: '/admin/analytics',
         icon: 'dashboard',
         description: 'Enter the canonical analytics workspace and choose the right reporting lens.',
+        tourDescription: 'The entry point for every analytics view — sponsorship, executive, marketing, and operations dashboards all start here.',
         accentColor: navAccent.primary,
       },
       {

--- a/lib/tour/config/segmentTourSteps.ts
+++ b/lib/tour/config/segmentTourSteps.ts
@@ -1,0 +1,34 @@
+import { adminNavSections } from '@/lib/adminNavigation';
+import { canAccessMenuItem } from '@/lib/permissions';
+import type { UserRole } from '@/lib/users';
+import type { TourStepConfig } from '../types';
+
+/**
+ * WHAT: builds one tour step per nav item in a sidebar section
+ * WHY: adminNavSections already carries an authored label + description for
+ *      every item -- deriving steps from it keeps the tour copy and the
+ *      nav item's own hover text as a single source of truth instead of
+ *      re-authoring the same explanation twice
+ */
+export function getSegmentTourSteps(sectionKey: string, userRole: UserRole | undefined): TourStepConfig[] {
+  const section = adminNavSections.find((s) => s.key === sectionKey);
+  if (!section) return [];
+
+  return section.items
+    .filter((item) => canAccessMenuItem(userRole, item.label))
+    .map((item) => ({
+      id: `nav-${item.path}`,
+      targetSelector: `[data-tour-id="nav-${item.path}"]`,
+      title: item.label,
+      description: item.tourDescription ?? item.description,
+    }));
+}
+
+/** Section metadata (title/description) used by the Tours menu to list segments. */
+export function getSegmentTourMeta() {
+  return adminNavSections.map((section) => ({
+    key: section.key,
+    title: section.title,
+    description: section.description,
+  }));
+}

--- a/lib/tour/config/welcomeTourSteps.ts
+++ b/lib/tour/config/welcomeTourSteps.ts
@@ -1,0 +1,25 @@
+import { adminNavSections } from '@/lib/adminNavigation';
+import { canAccessMenuItem } from '@/lib/permissions';
+import type { UserRole } from '@/lib/users';
+import type { TourStepConfig } from '../types';
+
+/**
+ * WHAT: one step per sidebar section, using each section's own title +
+ *       description from adminNavigation.ts
+ * WHY: a first-time admin needs the six groups introduced before any
+ *      individual segment tour makes sense -- this is the one tour whose
+ *      steps target section headers rather than individual nav items.
+ *      Sections with no accessible items for the current role are dropped
+ *      up front, since Sidebar.tsx itself doesn't render that section's
+ *      `data-tour-id` wrapper when there's nothing visible inside it.
+ */
+export function getWelcomeTourSteps(userRole: UserRole | undefined): TourStepConfig[] {
+  return adminNavSections
+    .filter((section) => section.items.some((item) => canAccessMenuItem(userRole, item.label)))
+    .map((section) => ({
+      id: `nav-section-${section.key}`,
+      targetSelector: `[data-tour-id="nav-section-${section.key}"]`,
+      title: section.title,
+      description: section.description,
+    }));
+}

--- a/lib/tour/storage.ts
+++ b/lib/tour/storage.ts
@@ -1,0 +1,60 @@
+// lib/tour/storage.ts
+// WHAT: Guided-tour "seen" state persistence
+// WHY: Mirrors lib/adminViewState.ts's style (plain functions, SSR-guarded,
+//      try/catch) so this doesn't introduce a new persistence pattern --
+//      the Tours menu reads this to show a completed checkmark per tour.
+
+'use client';
+
+import type { TourSeenRecord, TourSeenStatus } from './types';
+
+function storageKey(tourId: string): string {
+  return `mm-tour-${tourId}`;
+}
+
+/**
+ * WHAT: Check whether a tour has already been completed or skipped
+ * WHY: The Tours menu shows a checkmark instead of a plain "Start" button
+ *      once a tour has been seen
+ */
+export function hasTourBeenSeen(tourId: string): boolean {
+  if (typeof window === 'undefined') return false;
+
+  try {
+    return window.localStorage.getItem(storageKey(tourId)) !== null;
+  } catch (err) {
+    console.warn('Failed to read tour state from localStorage:', err);
+    return false;
+  }
+}
+
+/**
+ * WHAT: Record that a tour was completed or skipped
+ * WHY: Persists across sessions so the Tours menu reflects prior progress
+ */
+export function markTourSeen(tourId: string, status: TourSeenStatus): void {
+  if (typeof window === 'undefined') return;
+
+  try {
+    const record: TourSeenRecord = { status, at: new Date().toISOString() };
+    window.localStorage.setItem(storageKey(tourId), JSON.stringify(record));
+  } catch (err) {
+    console.warn('Failed to save tour state to localStorage:', err);
+  }
+}
+
+/**
+ * WHAT: Clear a tour's "seen" state
+ * WHY: Not currently used by the manual-trigger Tours menu (Start already
+ *      works as Replay regardless of prior completion), kept for parity
+ *      with markTourSeen/hasTourBeenSeen and possible future use.
+ */
+export function clearTourSeen(tourId: string): void {
+  if (typeof window === 'undefined') return;
+
+  try {
+    window.localStorage.removeItem(storageKey(tourId));
+  } catch (err) {
+    console.warn('Failed to clear tour state from localStorage:', err);
+  }
+}

--- a/lib/tour/types.ts
+++ b/lib/tour/types.ts
@@ -1,0 +1,23 @@
+import type { ReactNode } from 'react';
+
+/**
+ * One spotlighted step in a guided tour: `targetSelector` is a CSS selector
+ * (usually `[data-tour-id="..."]`) resolved against the live DOM at step
+ * time, not a ref -- the target may not exist yet when the tour is
+ * configured (e.g. it's hidden behind a role check that resolves async).
+ */
+export interface TourStepConfig {
+  id: string;
+  targetSelector: string;
+  title: ReactNode;
+  description: ReactNode;
+  /** Runtime check, e.g. "is this nav item visible for the current role". Omit for steps that are always available once included. */
+  isAvailable?: () => boolean;
+}
+
+export type TourSeenStatus = 'completed' | 'skipped';
+
+export interface TourSeenRecord {
+  status: TourSeenStatus;
+  at: string;
+}

--- a/lib/tour/useTourController.ts
+++ b/lib/tour/useTourController.ts
@@ -1,0 +1,100 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useOverlayManager } from '@sovereignsquad/gds-core/client';
+import type { TourStepConfig } from './types';
+import { markTourSeen } from './storage';
+
+export interface TourController {
+  isOpen: boolean;
+  isTopMost: boolean;
+  currentStep: TourStepConfig | null;
+  currentIndex: number;
+  totalSteps: number;
+  start: () => void;
+  next: () => void;
+  back: () => void;
+  skip: () => void;
+}
+
+/**
+ * Step-sequencing state for one guided tour. Registers with
+ * OverlayManagerProvider (mounted in components/AdminLayout.tsx) so it
+ * coordinates with the notification panel / other overlays instead of
+ * running an independent overlay stack. Tours here are always
+ * manually-triggered (from components/tour/TourMenu.tsx) -- there is no
+ * autoStart option, unlike the sibling implementation this was ported from.
+ */
+export function useTourController(tourId: string, steps: TourStepConfig[]): TourController {
+  const availableSteps = useMemo(
+    () => steps.filter((step) => step.isAvailable?.() ?? true),
+    [steps]
+  );
+
+  const [isOpen, setIsOpen] = useState(false);
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const overlayManager = useOverlayManager();
+
+  const finish = useCallback(
+    (status: 'completed' | 'skipped') => {
+      setIsOpen(false);
+      overlayManager.closeOverlay(tourId, status === 'completed' ? 'action' : 'programmatic');
+      overlayManager.unregisterOverlay(tourId);
+      markTourSeen(tourId, status);
+    },
+    [overlayManager, tourId]
+  );
+
+  const start = useCallback(() => {
+    if (availableSteps.length === 0) return;
+    setCurrentIndex(0);
+    setIsOpen(true);
+    overlayManager.registerOverlay({
+      id: tourId,
+      kind: 'popover',
+      policy: { closeOnEscape: true, closeOnOutsideClick: false, returnFocus: true },
+    });
+    overlayManager.openOverlay({ id: tourId, kind: 'popover' });
+  }, [availableSteps.length, overlayManager, tourId]);
+
+  // Reads currentIndex from the closure rather than a setCurrentIndex functional
+  // updater -- React can invoke an updater during another component's render,
+  // and finish() below has side effects (closes/unregisters a *different*
+  // component's overlay state), which isn't safe to do from inside one.
+  const next = useCallback(() => {
+    if (currentIndex + 1 >= availableSteps.length) {
+      finish('completed');
+      return;
+    }
+    setCurrentIndex(currentIndex + 1);
+  }, [currentIndex, availableSteps.length, finish]);
+
+  const back = useCallback(() => {
+    setCurrentIndex((index) => Math.max(0, index - 1));
+  }, []);
+
+  const skip = useCallback(() => {
+    finish('skipped');
+  }, [finish]);
+
+  // Always safe to unregister on unmount even if never opened -- the
+  // manager treats an unknown id as a no-op.
+  useEffect(() => {
+    return () => {
+      overlayManager.unregisterOverlay(tourId);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [tourId]);
+
+  return {
+    isOpen,
+    isTopMost: isOpen && overlayManager.isTopMost(tourId),
+    currentStep: isOpen ? availableSteps[currentIndex] ?? null : null,
+    currentIndex,
+    totalSteps: availableSteps.length,
+    start,
+    next,
+    back,
+    skip,
+  };
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "messmass",
-  "version": "12.1.37",
+  "version": "12.1.38",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "messmass",
-      "version": "12.1.37",
+      "version": "12.1.38",
       "license": "MIT",
       "dependencies": {
         "@mantine/core": "^8.3.18",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "messmass",
-  "version": "12.1.37",
+  "version": "12.1.38",
   "description": "Enterprise-grade event analytics platform with comprehensive partner management, intelligent link tracking, automated event creation (Sports Match Builder), and advanced real-time statistics dashboard for sports organizations, venues, brands, and event managers",
   "keywords": [
     "event-statistics",


### PR DESCRIPTION
# Pull Request

## DoD Profile
- [x] **Documentation** (STANDARD)
- [ ] Report Rendering &amp; Dashboards / Infrastructure &amp; Operations / Editor &amp; Builder / Security &amp; Validation — not applicable, this PR only touches the admin panel chrome and adds new, isolated files

## Required Status Checks (ALL must pass before merge)
- [x] **Build** — `npm run build` succeeds locally
- [x] **Type Check** — `npm run type-check` passes
- [x] **Lint** — `npm run lint` passes (zero warnings)
- [x] **Layout Grammar Guardrail** — `npx tsx scripts/check-layout-grammar-guardrail.ts` passes
- [x] **Dependency Guardrail** — `npx tsx scripts/check-dependency-guardrail.ts` passes (no new dependencies added)
- [x] `npm run style:check`, `npm run version:verify`, `npm run docs:audit`, `npm run test` all pass locally

## Context

**Branch:** `feature/guided-tour-onboarding`
**Base:** `main`
**Related Issue/Phase:** None — new feature, no existing tracked phase/issue

**Phase 5 File Touches:** No Phase 5 files touched (this repo's Phase 5/6 tracker system doesn't apply to this change)

## Changes

**What changed:**
- New tour engine: `lib/tour/*` (types, storage, `useTourController`, step config) and `components/tour/*` (`TourOverlay`, `TourMenu`)
- `components/AdminLayout.tsx` — mounts `OverlayManagerProvider` (`@sovereignsquad/gds-core`, already a dependency, not previously mounted anywhere), scoped to the admin layout only
- `components/TopHeader.tsx` — mounts the new `TourMenu` entry point next to the notifications bell
- `components/Sidebar.tsx` — adds `data-tour-id` attributes to nav items and section wrappers (the first DOM-targeting-attribute convention in this codebase)
- `lib/adminNavigation.ts` — adds an optional `tourDescription?` field to `AdminNavItem`, used for 7 items whose existing nav-hover-text `description` assumed prior knowledge
- Docs: `docs/architecture.md` (new "Guided Tour System" section), `docs/operations/operations-release-notes.md` (`[v12.1.38]`), version bump `12.1.37` → `12.1.38` (`package.json`, `package-lock.json`, and the 6 other docs whose version headers `docs:audit` checks)

**Why:**
A manually-triggered product tour so a new admin can get "what is an event / report / partner, how do the six sidebar sections work" explained in place, pointing at the real nav item — rather than needing a separate written guide.

**How:**
A from-scratch spotlight/backdrop overlay (dark backdrop, cutout on the target element, step tooltip) — nothing like it exists in this codebase or its dependencies. Tour step copy is *derived* from `adminNavigation.ts`'s existing `label`/`description` fields rather than re-authored, so nav hover text and tour copy stay a single source of truth. Fully manual trigger (no auto-start): a "Guided tours" `ActionIcon` + dropdown panel in `TopHeader.tsx`, structured like the existing `NotificationPanel.tsx` for visual/implementation consistency. Role-based step filtering reuses the existing `canAccessMenuItem`.

## Verification

**Tests:**
- [x] All existing tests pass (`npm run test` — 32 suites, 309 tests, all green; no regressions)
- [ ] No new automated tests added for the tour engine itself — see manual testing note below for why

**Manual Testing:**
- [x] Tested locally, with a caveat: this sandbox cannot reach messmass's MongoDB Atlas cluster (confirmed independently — even the public homepage's own DB-backed data fetch 500s here), so no route requiring a real authenticated admin session could be exercised end-to-end.
  - The interactive engine (spotlight measurement, retry-then-skip for a not-yet-mounted target, Tab focus-trap, Next/Back/Skip/Done — including the exact "advance past the last step" path — Escape-to-skip, `localStorage` persistence) **was** live-verified in a real browser, via a temporary scratch route that mounted the engine directly and bypassed the auth/DB chain. That route was deleted before this commit.
  - Role-based step filtering (`getSegmentTourSteps`, `getWelcomeTourSteps`) was verified directly against `guest`/`user`/`admin`/`superadmin` roles — each sees exactly the nav items `canAccessMenuItem` already grants it.
  - Full `Sidebar`/`TopHeader`/`TourMenu` integration under a real logged-in session was **not** live-verified, for the DB-connectivity reason above.
- [ ] Verified in preview deployment — not yet, will check once a preview is available
- [x] No console errors from the new code (the only console output observed during testing was pre-existing, unrelated: the app's own graceful MongoDB-unreachable fallback logging, and a pre-existing Mantine color-scheme hydration warning in the root layout)

## Impact

**Breaking Changes:** None
**Performance:** No measurable impact — the tour engine is idle (registers overlays but renders nothing) until a user opens the "Guided tours" menu and starts a tour
**Security:** None — no new data access, no new auth surface

## Documentation

- [x] `docs/architecture.md` updated (new "Guided Tour System" section)
- [x] `docs/operations/operations-release-notes.md` updated

## Checklist

- [x] No `console.log` statements added (only `console.error`/`console.warn` on genuine failure paths, matching existing conventions)
- [x] No `any` types introduced
- [x] Design tokens used, no hardcoded values (new CSS modules use existing `--mm-*` tokens)
- [x] No inline styles outside the few genuinely dynamic ones in `TourOverlay.tsx` (computed spotlight/tooltip position at runtime), each with a `// eslint-disable-next-line react/forbid-dom-props` and a WHAT/WHY comment per this repo's own convention
- [x] TypeScript strict mode passes
- [x] ESLint passes
- [x] All tests pass
- [x] Ready for review