### PR TITLE
Fix guided-tour panel overflowing off-screen on mobile

### DIFF
--- a/components/tour/TourMenu.module.css
+++ b/components/tour/TourMenu.module.css
@@ -106,7 +106,17 @@
 
 @media (max-width: 480px) {
   .tourPanel {
-    width: calc(100vw - var(--mm-space-8));
+    /* WHAT: switch from absolute (anchored to the small trigger icon) to
+       fixed (anchored to the viewport) on narrow screens
+       WHY: the trigger icon sits left-of-center in the header, not at the
+       right edge -- an absolutely-positioned wide panel anchored to it
+       overflows off the left edge of the screen on mobile */
+    position: fixed;
+    /* 72px matches .topHeader's own hardcoded height (TopHeader.module.css) -- not tokenized there either */
+    top: calc(72px + var(--mm-space-2));
+    left: var(--mm-space-4);
     right: var(--mm-space-4);
+    width: auto;
+    max-height: calc(100vh - 72px - var(--mm-space-8));
   }
 }

--- a/docs/_meta/meta-docs-consistency-audit.md
+++ b/docs/_meta/meta-docs-consistency-audit.md
@@ -1,6 +1,6 @@
 # Docs Consistency Audit
 Status: Active
-Last Updated: 2026-08-04T22:03:00.203Z
+Last Updated: 2026-08-05T08:38:41.179Z
 Canonical: Yes
 Owner: Documentation
 

--- a/docs/_meta/meta-docs-link-check.md
+++ b/docs/_meta/meta-docs-link-check.md
@@ -1,6 +1,6 @@
 # Docs Link Check
 Status: Active
-Last Updated: 2026-08-04T22:03:00Z
+Last Updated: 2026-08-05T08:38:41Z
 Canonical: Yes
 Owner: Documentation
 


### PR DESCRIPTION
## Context

**Branch:** `fix/tour-mobile-panel-position`
**Base:** `main`
**Related:** Follow-up to #313 (guided tour), user-reported via screenshots on a real mobile device.

## Changes

**What changed:**
- `components/tour/TourMenu.module.css` — mobile (`max-width: 480px`) breakpoint for `.tourPanel`.

**Why:**
The "Guided tours" trigger icon sits left-of-center in the admin header (before the notification bell), not at the right edge. `.tourPanel` is `position: absolute`, anchored to its own small trigger wrapper. The mobile override only changed `width`/`right`, but `right` was still relative to that narrow wrapper, not the viewport — so the near-full-width mobile panel overflowed roughly 190px off the left edge of the screen. Confirmed via user screenshots on an iPhone.

**How:**
Switched the mobile breakpoint to `position: fixed` with viewport-relative `left`/`right` insets instead of `position: absolute` relative to the trigger, decoupling the panel's placement from wherever the icon happens to sit in the header.

## Verification

**Manual Testing:**
- [x] Reproduced the exact bug via a temporary scratch route (deleted before commit) rendering the real `AdminLayout`/`TopHeader`/`TourMenu` at mobile viewport widths (360–390px) — confirmed the panel previously extended off-screen.
- [x] After the fix, confirmed via the same harness that the panel's bounding box stays fully within a 390px viewport (`x: 16, width: 358` — comfortably inside `0–390`).
- [x] Full local gate: `type-check`, `lint`, `test` (309/309 passing), `style:check`, `version:verify`, `docs:audit`, dependency + layout-grammar guardrails, `build` — all clean.

**CI Status:**
- [x] All required checks passing

## Impact

**Breaking Changes:** None — CSS-only change scoped to one component's mobile breakpoint.
**Performance:** None.
**Security:** None.

## Documentation

No doc changes needed — this is a bugfix to behavior documented in `docs/architecture.md`'s "Guided Tour System" section from #313, not a new capability.