### PR TITLE
Fix notification panel overflowing off-screen on mobile

### DIFF
--- a/components/NotificationPanel.module.css
+++ b/components/NotificationPanel.module.css
@@ -324,10 +324,20 @@
 }
 
 /* WHAT: Responsive adjustments
- * WHY: Adapt panel width for mobile devices */
+ * WHY: Adapt panel width for mobile devices. Switches from absolute (anchored
+ *      to the bell icon) to fixed (anchored to the viewport) -- the bell
+ *      doesn't sit at the true right edge of the header (avatar/logout
+ *      controls follow it), so a wide panel anchored to it with `right`
+ *      still relative to that narrow wrapper overflowed off the left edge
+ *      of the screen on phones. See components/tour/TourMenu.module.css for
+ *      the same fix applied to the guided-tour panel. */
 @media (max-width: 480px) {
   .notificationPanel {
-    width: calc(100vw - var(--mm-space-8));
+    position: fixed;
+    top: calc(72px + var(--mm-space-2));
+    left: var(--mm-space-4);
     right: var(--mm-space-4);
+    width: auto;
+    max-height: calc(100vh - 72px - var(--mm-space-8));
   }
 }

--- a/docs/_meta/meta-docs-consistency-audit.md
+++ b/docs/_meta/meta-docs-consistency-audit.md
@@ -1,6 +1,6 @@
 # Docs Consistency Audit
 Status: Active
-Last Updated: 2026-08-05T08:38:41.179Z
+Last Updated: 2026-08-05T09:01:22.327Z
 Canonical: Yes
 Owner: Documentation
 

--- a/docs/_meta/meta-docs-link-check.md
+++ b/docs/_meta/meta-docs-link-check.md
@@ -1,6 +1,6 @@
 # Docs Link Check
 Status: Active
-Last Updated: 2026-08-05T08:38:41Z
+Last Updated: 2026-08-05T09:01:22Z
 Canonical: Yes
 Owner: Documentation
 


### PR DESCRIPTION
## Context

**Branch:** `fix/notification-panel-mobile-position`
**Base:** `main`
**Related:** Same bug shape as #314 (guided-tour panel), pre-existing and unrelated to that feature — found while double-checking that #314's fix pattern hadn't been copied from something already broken.

## Changes

**What changed:**
- `components/NotificationPanel.module.css` — mobile (`max-width: 480px`) breakpoint for `.notificationPanel`.

**Why:**
`.notificationPanel` is `position: absolute`, anchored to the bell icon's own narrow wrapper (`.notificationsBell`). The bell doesn't sit at the true right edge of the header — the avatar and logout controls follow it. The mobile override only changed `width`/`right`, but `right` stayed relative to that narrow wrapper, not the viewport, so the panel overflowed off the left edge of the screen on phones.

**How:**
Same fix as #314: switched the mobile breakpoint to `position: fixed` with viewport-relative `left`/`right` insets instead of `position: absolute` relative to the trigger.

## Verification

**Manual Testing:**
- [x] Reproduced via a temporary scratch route (deleted before commit) rendering the real `AdminLayout`/`TopHeader` and opening the panel at mobile viewport widths.
- [x] After the fix, confirmed across three widths (360px/375px/390px) that both the notification panel and the guided-tour panel stay fully within the viewport at each — re-verified the tour panel too, not just this one.
- [x] Full local gate: `type-check`, `lint`, `test` (309/309 passing), `style:check`, `version:verify`, `docs:audit`, dependency + layout-grammar guardrails, `build` — all clean.

**CI Status:**
- [x] All required checks passing

## Impact

**Breaking Changes:** None — CSS-only change scoped to one component's mobile breakpoint.
**Performance:** None.
**Security:** None.

## Documentation

No doc changes needed — this restores intended behavior of an existing, already-documented component; not a new capability.