### PR TITLE
Migrate hashtag chip UI to GDS ChoiceChip

### DIFF
--- a/app/admin/events/ProjectsPageClient.tsx
+++ b/app/admin/events/ProjectsPageClient.tsx
@@ -778,6 +778,7 @@ export default function ProjectsPageClient({ user }: ProjectsPageClientProps) {
                                     // Open share popup for single-hashtag filter (same flow as Admin → Filter)
                                     shareSingleHashtag(hashtag, project.styleIdEnhanced || null);
                                   }}
+                                  ariaLabel={`Share ${hashtag}`}
                                   projectCategorizedHashtags={project.categorizedHashtags}
                                   autoResolveColor={true}
                                 />
@@ -800,6 +801,7 @@ export default function ProjectsPageClient({ user }: ProjectsPageClientProps) {
                                       // Open share popup for category-prefixed single-hashtag filter
                                       shareSingleHashtag(hashtag, project.styleIdEnhanced || null);
                                     }}
+                                    ariaLabel={`Share ${category}:${hashtag}`}
                                     projectCategorizedHashtags={project.categorizedHashtags}
                                     autoResolveColor={true}
                                   />

--- a/components/ColoredHashtagBubble.module.css
+++ b/components/ColoredHashtagBubble.module.css
@@ -1,82 +1,28 @@
-/* What: Modern hashtag bubble styling with TailAdmin V2 design
-   Why: Clean, professional pill design for hashtags
-   
-   Design principles:
-   - Clean rounded pills with proper spacing
-   - Hover and focus states for interactive mode
-   - Remove button with smooth interaction
-   - Responsive sizing (normal and small variants)
-   - High contrast for accessibility */
+/* What: Remove-affordance styling for hashtag chips
+   Why: GDS's ChoiceChip/Badge owns the chip shell (padding, radius, color,
+   hover/focus states, disabled/print handling) once ColoredHashtagBubble
+   renders through it -- this module only styles the one piece of UI GDS
+   doesn't provide out of the box: the inline "×" remove control. */
 
-.hashtag {
+/* Real <button> remove control, used when the chip itself is NOT interactive
+   (so nesting a real button inside the non-interactive Badge is valid). */
+.removeButton {
   display: inline-flex;
   align-items: center;
-  gap: var(--mm-space-1);
-  padding: var(--mm-space-1) var(--mm-space-3);
-  border-radius: var(--mm-radius-full);
-  font-size: var(--mm-font-size-sm);
-  font-weight: var(--mm-font-weight-medium);
-  line-height: var(--mm-line-height-sm);
-  color: white;
-  white-space: nowrap;
-  transition: all 0.15s ease;
-  position: relative;
-  border: 1px solid rgba(255, 255, 255, 0.2);
-}
-
-/* What: Small size variant
-   Why: Compact display for dense layouts */
-.hashtagSmall {
-  padding: 2px var(--mm-space-2);
-  font-size: var(--mm-font-size-xs);
-  gap: 2px;
-}
-
-/* What: Interactive state
-   Why: Visual feedback for clickable hashtags */
-.hashtagInteractive {
-  cursor: pointer;
-}
-
-.hashtagInteractive:hover {
-  transform: translateY(-1px);
-  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.15);
-  border-color: rgba(255, 255, 255, 0.4);
-}
-
-.hashtagInteractive:active {
-  transform: translateY(0);
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
-}
-
-/* What: Removable state
-   Why: Extra padding for remove button */
-.hashtagRemovable {
-  padding-right: var(--mm-space-2);
-}
-
-.hashtagRemovable.hashtagSmall {
-  padding-right: var(--mm-space-1);
-}
-
-/* What: Remove button styling
-   Why: Clear, accessible remove action */
-.removeButton {
-  display: flex;
-  align-items: center;
   justify-content: center;
+  vertical-align: middle;
   background: rgba(255, 255, 255, 0.25);
   border: none;
-  border-radius: var(--mm-radius-full);
-  color: white;
+  border-radius: 999px;
+  color: inherit;
   cursor: pointer;
   width: 16px;
   height: 16px;
   font-size: 12px;
-  font-weight: var(--mm-font-weight-bold);
+  font-weight: 700;
   line-height: 1;
   padding: 0;
-  margin-left: var(--mm-space-1);
+  margin-left: 4px;
   transition: all 0.15s ease;
 }
 
@@ -90,78 +36,31 @@
 }
 
 .removeButton:focus-visible {
-  outline: 2px solid white;
+  outline: 2px solid currentColor;
   outline-offset: 1px;
 }
 
-/* What: Small remove button
-   Why: Proportional sizing for small hashtags */
 .removeButtonSmall {
   width: 14px;
   height: 14px;
   font-size: 10px;
 }
 
-/* What: Focus state for accessibility
-   Why: Keyboard navigation support */
-.hashtag:focus-visible {
-  outline: 2px solid white;
-  outline-offset: 2px;
+/* Decorative-only "×" glyph, used when the chip itself IS interactive (a real
+   <button>) -- the whole chip already removes on click, so this is not a
+   second interactive control (see ColoredHashtagBubble.tsx for why). */
+.removeGlyph {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  vertical-align: middle;
+  margin-left: 4px;
+  font-size: 12px;
+  font-weight: 700;
+  line-height: 1;
+  opacity: 0.85;
 }
 
-/* What: Disabled state
-   Why: Visual feedback for non-interactive hashtags */
-.hashtagDisabled {
-  opacity: 0.6;
-  cursor: not-allowed;
-}
-
-.hashtagDisabled:hover {
-  transform: none;
-  box-shadow: none;
-}
-
-/* What: Animation for adding/removing
-   Why: Smooth transitions when hashtags change */
-@keyframes fadeIn {
-  from {
-    opacity: 0;
-    transform: scale(0.8);
-  }
-  to {
-    opacity: 1;
-    transform: scale(1);
-  }
-}
-
-.hashtagAnimated {
-  animation: fadeIn 0.2s ease;
-}
-
-/* What: Responsive adjustments
-   Why: Better touch targets on mobile */
-@media (max-width: 768px) {
-  .hashtag {
-    padding: var(--mm-space-2) var(--mm-space-3);
-    font-size: var(--mm-font-size-sm);
-  }
-
-  .removeButton {
-    width: 18px;
-    height: 18px;
-    font-size: 13px;
-  }
-}
-
-/* What: Print styles
-   Why: Clean hashtag display when printed */
-@media print {
-  .hashtag {
-    border: 1px solid currentColor;
-    box-shadow: none;
-  }
-
-  .removeButton {
-    display: none;
-  }
+.removeGlyphSmall {
+  font-size: 10px;
 }

--- a/components/ColoredHashtagBubble.tsx
+++ b/components/ColoredHashtagBubble.tsx
@@ -32,6 +32,12 @@ interface ColoredHashtagBubbleProps {
   categoryColor?: string;
   removable?: boolean;
   onRemove?: () => void;
+  // WHAT: Optional accessible-name override for interactive chips.
+  // WHY: This component is reused for genuinely different actions (toggle a filter,
+  // open a share popup, ...) -- it cannot guess which one a given caller means, so it
+  // must not hardcode one. Omit it and the chip's visible text ("#hashtag") serves as
+  // the accessible name, which is always at least accurate, if generic.
+  ariaLabel?: string;
   // New props for intelligent color resolution
   projectCategorizedHashtags?: { [categoryName: string]: string[] };
   autoResolveColor?: boolean;
@@ -50,6 +56,7 @@ function ColoredHashtagBubbleComponent({
   categoryColor,
   removable = false,
   onRemove,
+  ariaLabel,
   projectCategorizedHashtags,
   autoResolveColor = false
 }: ColoredHashtagBubbleProps) {
@@ -168,7 +175,7 @@ function ColoredHashtagBubbleComponent({
       style={customStyle}
       title={`Hashtag color: ${safeBackgroundColor}`}
       onClick={interactive ? handleClick : undefined}
-      aria-label={interactive ? `Toggle ${hStr} filter` : undefined}
+      aria-label={ariaLabel}
     />
   );
 }

--- a/components/ColoredHashtagBubble.tsx
+++ b/components/ColoredHashtagBubble.tsx
@@ -1,18 +1,25 @@
 'use client';
 
 import { useMemo, memo } from 'react';
+import { ChoiceChip } from '@sovereignsquad/gds-core/client';
+import type React from 'react';
 import useHashtagColorResolver from '../hooks/useHashtagColorResolver';
 import { compareHashtagBubbleProps } from '../lib/performanceUtils';
 import styles from './ColoredHashtagBubble.module.css';
 
-/* What: Modernized hashtag bubble component with TailAdmin V2 styling
-   Why: Professional pill design with proper interaction states
-   
-   Changes:
-   - CSS Modules for better styling encapsulation
-   - Improved accessibility with proper focus states
-   - Smooth animations and transitions
-   - Better touch targets for mobile */
+/* What: Hashtag bubble rendered through GDS's ChoiceChip/Badge primitive
+   Why: Replaces a hand-rolled <span>/<button> pill with the shared design
+   system's chip so hashtags get token-driven styling instead of a
+   page-local pattern. See docs/components/components-reusable-components-inventory.md
+   ("Hashtag System" section) for the full rationale. */
+
+// WHAT: ChoiceChipProps doesn't declare every native attribute Badge forwards once it
+// renders with onClick (component="button" internally, per Mantine's polymorphic Badge)
+// -- `title` is a real, runtime-forwarded prop, just not typed on GDS's ChoiceChip
+// wrapper. Cast once here rather than reaching for `any` at the call site.
+const HashtagChoiceChip = ChoiceChip as React.ComponentType<
+  React.ComponentProps<typeof ChoiceChip> & { title?: string }
+>;
 
 interface ColoredHashtagBubbleProps {
   hashtag: string;
@@ -32,10 +39,10 @@ interface ColoredHashtagBubbleProps {
 
 // WHAT: Memoized hashtag bubble component to prevent unnecessary re-renders
 // WHY: Hashtags are rendered in large lists; memoization reduces render overhead
-function ColoredHashtagBubbleComponent({ 
-  hashtag, 
-  className = '', 
-  small = false, 
+function ColoredHashtagBubbleComponent({
+  hashtag,
+  className = '',
+  small = false,
   customStyle = {},
   interactive = false,
   onClick,
@@ -68,12 +75,12 @@ function ColoredHashtagBubbleComponent({
     if (categoryColor) {
       return categoryColor;
     }
-    
+
     // If auto-resolve is enabled and we have project context, use intelligent resolution
     if (autoResolveColor && projectCategorizedHashtags) {
       return resolveHashtagColor(hStr, projectCategorizedHashtags);
     }
-    
+
     // Legacy fallback: use individual hashtag color or default
     const colorInfo = getHashtagColorInfo(hStr, projectCategorizedHashtags);
     return colorInfo.effectiveColor;
@@ -86,15 +93,6 @@ function ColoredHashtagBubbleComponent({
     }
     return hStr;
   }, [showCategoryPrefix, hashtagCategory, hStr]);
-  /* What: Build CSS Module classes dynamically
-     Why: Combine base styles with variant modifiers */
-  const bubbleClasses = [
-    styles.hashtag,
-    small && styles.hashtagSmall,
-    interactive && styles.hashtagInteractive,
-    removable && styles.hashtagRemovable,
-    className
-  ].filter(Boolean).join(' ');
 
   // Handle empty hashtag gracefully
   if (!hStr || !hStr.trim()) {
@@ -102,7 +100,7 @@ function ColoredHashtagBubbleComponent({
   }
 
   // Handle click functionality
-  const handleClick = () => {
+  const handleClick: React.MouseEventHandler<HTMLElement> = () => {
     if (interactive && onClick) {
       onClick(hStr);
     }
@@ -132,41 +130,46 @@ function ColoredHashtagBubbleComponent({
   // WHAT: Validate backgroundColor before using in style
   // WHY: React calls .trim() on style values, will crash if undefined
   const safeBackgroundColor = (backgroundColor && typeof backgroundColor === 'string' && backgroundColor.trim()) ? backgroundColor : '#3b82f6';
-  
+
+  // WHAT: interactive chips render as a real <button> (ChoiceChip's onClick branch); a
+  // removable chip that's ALSO interactive can't nest a second real <button> inside a
+  // <button> (invalid HTML). In that combination the "×" is decorative only — the whole
+  // chip already removes on click, which matches every current call site where onClick
+  // and onRemove invoke the same handler. A removable-but-not-interactive chip renders as
+  // a plain (non-button) Badge, so a real nested remove <button> stays valid there.
+  const removeGlyph = removable ? (
+    interactive ? (
+      <span aria-hidden className={`${styles.removeGlyph} ${small ? styles.removeGlyphSmall : ''}`}>×</span>
+    ) : (
+      <button
+        type="button"
+        onClick={handleRemove}
+        className={`${styles.removeButton} ${small ? styles.removeButtonSmall : ''}`}
+        title="Remove hashtag"
+        aria-label="Remove hashtag"
+      >
+        ×
+      </button>
+    )
+  ) : null;
+
   return (
-    <span 
-      className={bubbleClasses}
-      // WHAT: Dynamic hashtag bubble styling based on category/hashtag color + props
-      // WHY: backgroundColor computed from MongoDB category data, cursor/gap from interactive/removable flags
-      // HOW: Color resolution uses intelligent resolver based on project categorizedHashtags
-      // NOTE: customStyle prop allows component reuse with flexible sizing (fontSize/fontWeight)
-      // eslint-disable-next-line react/forbid-dom-props
-      style={{
-        backgroundColor: safeBackgroundColor,
-        background: safeBackgroundColor, // Ensure both properties are set
-        color: 'white', // Force text color to always be white
-        cursor: interactive ? 'pointer' : 'default',
-        position: 'relative',
-        display: 'inline-flex',
-        alignItems: 'center',
-        gap: removable ? '0.25rem' : '0',
-        ...customStyle 
-      }}
+    <HashtagChoiceChip
+      label={
+        <>
+          #{displayText}
+          {removeGlyph}
+        </>
+      }
+      active // always filled/solid, matching this bubble's original always-colored look
+      color={safeBackgroundColor}
+      size={small ? 'xs' : 'sm'}
+      className={className}
+      style={customStyle}
       title={`Hashtag color: ${safeBackgroundColor}`}
-      onClick={handleClick}
-    >
-      #{displayText}
-      {removable && (
-        <button
-          onClick={handleRemove}
-          className={`${styles.removeButton} ${small ? styles.removeButtonSmall : ''}`}
-          title="Remove hashtag"
-          aria-label="Remove hashtag"
-        >
-          ×
-        </button>
-      )}
-    </span>
+      onClick={interactive ? handleClick : undefined}
+      aria-label={interactive ? `Toggle ${hStr} filter` : undefined}
+    />
   );
 }
 

--- a/components/HashtagMultiSelect.module.css
+++ b/components/HashtagMultiSelect.module.css
@@ -112,48 +112,30 @@
   gap: var(--mm-space-3);
 }
 
-/* Hashtag Item (Checkbox Label) */
+/* Hashtag Item -- selection is a GDS ChoiceChip now (real <button>, active
+   state shown via its own filled/light variant); this class only handles
+   grid-item layout/sizing, not color/background, so it doesn't fight the
+   chip's own token-driven styling. */
 .hashtagItem {
   display: flex;
   align-items: center;
+  width: 100%;
+  height: auto;
   padding: var(--mm-space-3);
-  background: rgba(255, 255, 255, 0.9);
-  border: 2px solid rgba(229, 231, 235, 0.5);
-  border-radius: var(--mm-radius-xl);
-  cursor: pointer;
-  transition: all var(--transition-base);
+  white-space: normal;
+  transition: transform var(--transition-base);
 }
 
 .hashtagItem:hover {
   transform: scale(1.02);
-  box-shadow: var(--mm-shadow-md);
-}
-
-.hashtagItem.selected {
-  background: rgba(99, 102, 241, 0.1);
-  border-color: rgba(99, 102, 241, 0.3);
 }
 
 .hashtagItem.disabled {
   cursor: not-allowed;
-  opacity: 0.6;
 }
 
 .hashtagItem.disabled:hover {
   transform: none;
-  box-shadow: none;
-}
-
-/* Checkbox */
-.checkbox {
-  margin-right: var(--mm-space-3);
-  width: 1.25rem;
-  height: 1.25rem;
-  cursor: pointer;
-}
-
-.checkbox:disabled {
-  cursor: not-allowed;
 }
 
 /* Hashtag Content */

--- a/components/HashtagMultiSelect.tsx
+++ b/components/HashtagMultiSelect.tsx
@@ -1,8 +1,17 @@
 'use client';
 
 import React, { useState, useEffect } from 'react';
+import { ChoiceChip } from '@sovereignsquad/gds-core/client';
 import ColoredHashtagBubble from './ColoredHashtagBubble';
 import styles from './HashtagMultiSelect.module.css';
+
+// WHAT: ChoiceChipProps doesn't declare the native <button> attributes Badge forwards
+// once it renders with onClick (component="button" internally) -- `disabled` is a real,
+// runtime-forwarded prop (Mantine's Badge is polymorphic), just not typed on GDS's
+// ChoiceChip wrapper. Cast once here rather than reaching for `any` at the call site.
+const SelectableChoiceChip = ChoiceChip as React.ComponentType<
+  React.ComponentProps<typeof ChoiceChip> & { disabled?: boolean }
+>;
 
 interface HashtagItem {
   hashtag: string;
@@ -191,6 +200,35 @@ export default function HashtagMultiSelect({
             return acc;
           }, {} as Record<string, typeof sortedHashtags>);
           
+          const renderHashtagGridItem = (item: HashtagItem) => {
+            const isSelected = selectedHashtags.includes(item.hashtag);
+            return (
+              <SelectableChoiceChip
+                key={item.hashtag}
+                active={isSelected}
+                onClick={() => handleHashtagToggle(item.hashtag)}
+                disabled={disabled}
+                className={`${styles.hashtagItem} ${disabled ? styles.disabled : ''}`}
+                aria-label={`${item.hashtag}, ${item.count} project${item.count === 1 ? '' : 's'}${isSelected ? ', selected' : ''}`}
+                label={
+                  <span className={styles.hashtagContent}>
+                    <ColoredHashtagBubble
+                      hashtag={item.hashtag}
+                      small
+                      customStyle={{
+                        fontSize: '0.875rem',
+                        fontWeight: '500'
+                      }}
+                    />
+                    <span className={styles.countBadge}>
+                      {item.count}
+                    </span>
+                  </span>
+                }
+              />
+            );
+          };
+
           return (
             <div>
               {/* Traditional Hashtags */}
@@ -200,36 +238,11 @@ export default function HashtagMultiSelect({
                     🏷️ General Hashtags ({traditionalHashtags.length})
                   </h5>
                   <div className={styles.hashtagsGrid}>
-                    {traditionalHashtags.map((item) => (
-                      <label
-                        key={item.hashtag}
-                        className={`${styles.hashtagItem} ${selectedHashtags.includes(item.hashtag) ? styles.selected : ''} ${disabled ? styles.disabled : ''}`}
-                      >
-                        <input
-                          type="checkbox"
-                          checked={selectedHashtags.includes(item.hashtag)}
-                          onChange={() => handleHashtagToggle(item.hashtag)}
-                          disabled={disabled}
-                          className={styles.checkbox}
-                        />
-                        <div className={styles.hashtagContent}>
-                          <ColoredHashtagBubble 
-                            hashtag={item.hashtag}
-                            customStyle={{
-                              fontSize: '0.875rem',
-                              fontWeight: '500'
-                            }}
-                          />
-                          <span className={styles.countBadge}>
-                            {item.count}
-                          </span>
-                        </div>
-                      </label>
-                    ))}
+                    {traditionalHashtags.map(renderHashtagGridItem)}
                   </div>
                 </div>
               )}
-              
+
               {/* Categorized Hashtags */}
               {Object.entries(categorizedByCategory).map(([category, categoryHashtags]) => (
                 <div key={category} className={styles.categorySection}>
@@ -237,32 +250,7 @@ export default function HashtagMultiSelect({
                     📂 {category.charAt(0).toUpperCase() + category.slice(1)} Category ({categoryHashtags.length})
                   </h5>
                   <div className={styles.hashtagsGrid}>
-                    {categoryHashtags.map((item) => (
-                      <label
-                        key={item.hashtag}
-                        className={`${styles.hashtagItem} ${selectedHashtags.includes(item.hashtag) ? styles.selected : ''} ${disabled ? styles.disabled : ''}`}
-                      >
-                        <input
-                          type="checkbox"
-                          checked={selectedHashtags.includes(item.hashtag)}
-                          onChange={() => handleHashtagToggle(item.hashtag)}
-                          disabled={disabled}
-                          className={styles.checkbox}
-                        />
-                        <div className={styles.hashtagContent}>
-                          <ColoredHashtagBubble 
-                            hashtag={item.hashtag}
-                            customStyle={{
-                              fontSize: '0.875rem',
-                              fontWeight: '500'
-                            }}
-                          />
-                          <span className={styles.countBadge}>
-                            {item.count}
-                          </span>
-                        </div>
-                      </label>
-                    ))}
+                    {categoryHashtags.map(renderHashtagGridItem)}
                   </div>
                 </div>
               ))}

--- a/components/HashtagMultiSelect.tsx
+++ b/components/HashtagMultiSelect.tsx
@@ -143,7 +143,7 @@ export default function HashtagMultiSelect({
                     AND
                   </span>
                 )}
-                <ColoredHashtagBubble 
+                <ColoredHashtagBubble
                   hashtag={hashtag}
                   customStyle={{
                     fontSize: '1rem',
@@ -153,6 +153,7 @@ export default function HashtagMultiSelect({
                   onRemove={() => handleHashtagToggle(hashtag)}
                   interactive={true}
                   onClick={() => handleHashtagToggle(hashtag)}
+                  ariaLabel={`Remove ${hashtag} filter`}
                 />
               </div>
             ))}

--- a/docs/_meta/meta-docs-consistency-audit.md
+++ b/docs/_meta/meta-docs-consistency-audit.md
@@ -1,10 +1,10 @@
 # Docs Consistency Audit
 Status: Active
-Last Updated: 2026-08-05T09:01:22.327Z
+Last Updated: 2026-08-08T16:43:13.163Z
 Canonical: Yes
 Owner: Documentation
 
-Package version: 12.1.38
+Package version: 12.1.39
 Current docs scanned: 134
 Failures: 0
 

--- a/docs/_meta/meta-docs-link-check.md
+++ b/docs/_meta/meta-docs-link-check.md
@@ -1,6 +1,6 @@
 # Docs Link Check
 Status: Active
-Last Updated: 2026-08-05T09:01:22Z
+Last Updated: 2026-08-08T16:43:13Z
 Canonical: Yes
 Owner: Documentation
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -4,7 +4,7 @@ Last Updated: 2026-06-25
 Canonical: No
 Owner: Architecture
 
-Version: 12.1.38
+Version: 12.1.39
 
 **Mantine Entity, Variant, and Public Report Shell Delivery (2026-06-25):**
 - **Report variant selector recovery:** Mantine `Select` dropdowns inside report variant `FormModal` now render through a portal with modal-safe z-index, preventing the dropdown from being hidden behind or interpreted as outside the dialog.

--- a/docs/components/components-reusable-components-inventory.md
+++ b/docs/components/components-reusable-components-inventory.md
@@ -1,11 +1,11 @@
 # {messmass} Reusable Components & Styling System Inventory
 Status: Active
-Last Updated: 2026-04-24
+Last Updated: 2026-08-08
 Canonical: No
 Owner: Architecture
 
-**Version**: 12.1.38
-**Last Updated**: 2026-04-24 (UTC)
+**Version**: 12.1.39
+**Last Updated**: 2026-08-08 (UTC)
 **Purpose**: Complete catalog of all reusable components, modules, styling systems, and utilities
 
 ---
@@ -163,22 +163,65 @@ import UnifiedHashtagInput from '@/components/UnifiedHashtagInput';
 
 #### ColoredHashtagBubble (Display)
 **File**: `components/ColoredHashtagBubble.tsx`
-**CSS**: `components/ColoredHashtagBubble.module.css`
+**CSS**: `components/ColoredHashtagBubble.module.css` (remove-affordance styling only —
+see below)
 **Usage**: Display hashtags with categories
 ```tsx
 import ColoredHashtagBubble from '@/components/ColoredHashtagBubble';
 <ColoredHashtagBubble
   hashtag="country:hungary"
-  color="#3b82f6"
+  categoryColor="#3b82f6"
   onRemove={() => {}}
+  removable={true}
   interactive={true}
+  onClick={(hashtag) => {}}
 />
 ```
+
+**Implementation (2026-08-08, GDS migration)**: renders through GDS's `ChoiceChip`
+(`@sovereignsquad/gds-core/client`) instead of a hand-rolled `<span>`/`<button>` pill —
+`ColoredHashtagBubble.module.css` now only styles the inline "×" remove affordance, not
+the chip shell (padding/radius/color/hover/focus/disabled/print), which GDS owns. The
+external prop contract (`hashtag`/`small`/`interactive`/`onClick`/`removable`/`onRemove`/
+`categoryColor`/`projectCategorizedHashtags`/`autoResolveColor`) is unchanged — all
+existing call sites work as-is.
+
+One structural rule this introduces: **`interactive` and `removable` can both be `true`
+on the same bubble, but the remove control changes shape depending on which.** An
+`interactive` chip renders as a real `<button>` (GDS's `ChoiceChip` `onClick` branch);
+HTML forbids nesting a second interactive control inside a `<button>`, so when both flags
+are set the "×" is decorative only (`aria-hidden` `<span>`) and the *whole chip* removes
+on click — this only makes sense (and is only used) where `onClick`/`onRemove` already
+invoke the same handler, as in `HashtagMultiSelect`'s selected-filters row. A
+`removable`-but-not-`interactive` chip (e.g. `UnifiedHashtagInput`'s entry chips) renders
+as a non-interactive `Badge`, so a real nested `<button>` for removal stays valid HTML.
+**Do not add a case that needs an `interactive` chip with an independently-clickable
+remove control** — that combination cannot be valid HTML with this primitive; redesign
+the interaction instead (e.g. split into two adjacent controls) rather than forcing it.
 
 **Examples**:
 - `app/admin/projects/ProjectsPageClient.tsx` (lines 450-480)
 - `app/admin/filter/page.tsx` (lines 120-150)
 - `app/edit/[slug]/page.tsx` (lines 300-330)
+- `components/HashtagMultiSelect.tsx` — selected-filters row (`interactive` +
+  `removable` together) and the selection grid, which composes a display-only
+  `ColoredHashtagBubble` as the `label` inside a selecting `ChoiceChip` (see below)
+
+#### HashtagMultiSelect (Filter selection)
+**File**: `components/HashtagMultiSelect.tsx`
+**Usage**: The hashtag filter bar's multi-select grid (`app/admin/filter/page.tsx`)
+
+**Implementation (2026-08-08, GDS migration)**: the selection grid previously used
+`<label><input type="checkbox"/>…</label>` wrapping a non-interactive
+`ColoredHashtagBubble`. Migrated to GDS's `ChoiceChip` driving selection directly
+(`active`/`onClick`, `aria-pressed` under the hood) instead of a checkbox, since
+`ChoiceChip` is explicitly meant for "lightweight selection, mode toggles, and taxonomy
+links" (its own JSDoc). Each grid item is now one `ChoiceChip` whose `label` composes a
+display-only `ColoredHashtagBubble` (carries the per-hashtag category color) plus the
+count badge — a real button wrapping a non-interactive badge, which is valid nesting.
+This dropped the card-style `.hashtagItem` background/border/selected-highlight CSS in
+favor of `ChoiceChip`'s own filled/light variant to show selection state, rather than
+layering a second, competing background on top of it.
 
 ---
 

--- a/docs/components/components-unified-input-system.md
+++ b/docs/components/components-unified-input-system.md
@@ -4,7 +4,7 @@ Last Updated: 2026-01-11T22:28:38.000Z
 Canonical: No
 Owner: Architecture
 
-**Version**: 12.1.38
+**Version**: 12.1.39
 **Last Updated**: 2026-01-11T22:28:38.000Z
 **Status**: Production-Ready
 

--- a/docs/design/design-system.md
+++ b/docs/design/design-system.md
@@ -60,6 +60,12 @@ Local UI code may adapt GDS primitives to Messmass domain needs, but it must not
 - **Props contract**: unchanged externally for `ColoredHashtagBubble`
   (`hashtag`/`small`/`interactive`/`onClick`/`removable`/`onRemove`/`categoryColor`/
   `projectCategorizedHashtags`/`autoResolveColor`) — all 14 existing call sites work as-is.
+  One new optional prop: `ariaLabel`. `ColoredHashtagBubble` is reused for genuinely
+  different `interactive` actions across the app (toggle a filter, open a share popup, …)
+  — it cannot guess which one a given caller means, so it never hardcodes a description.
+  Omit `ariaLabel` and the chip's visible text (`#hashtag`) is the accessible name, which
+  is always at least accurate; pass it when a caller's action needs a more specific
+  description (e.g. `"Remove {hashtag} filter"`).
 - **Accessibility behavior**: interactive chips are real `<button>`s (native keyboard
   reachability, focus state, `aria-pressed` on selection chips). An `interactive` +
   `removable` chip can't nest a second real button (invalid HTML), so in that combination

--- a/docs/design/design-system.md
+++ b/docs/design/design-system.md
@@ -1,10 +1,10 @@
 # {messmass} Design System
 Status: Active
-Last Updated: 2026-06-26T10:00:00.000Z
+Last Updated: 2026-08-08T16:40:43.000Z
 Canonical: Yes
 Owner: Architecture
 
-**Version**: 12.1.38
+**Version**: 12.1.39
 **Status**: Production
 
 ## Purpose
@@ -42,8 +42,42 @@ Local UI code may adapt GDS primitives to Messmass domain needs, but it must not
 | `FormModal` / `BaseModal` | Modal workflows that need consistent accessible structure |
 | `ConfirmDialog` | Destructive confirmation flows |
 | `UnifiedHashtagInput` | Hashtag selection and categorized hashtag input |
+| `ColoredHashtagBubble` | Hashtag display/selection/removal chip, over GDS `ChoiceChip` |
+| `HashtagMultiSelect` | Hashtag filter-bar multi-select, over GDS `ChoiceChip` |
 | `ReportChart` | Report chart rendering |
 | `ReportContent` | Report block layout |
+
+### `ColoredHashtagBubble` / `HashtagMultiSelect` (2026-08-08 GDS migration)
+
+- **GDS primitive used**: `ChoiceChip` (`@sovereignsquad/gds-core/client`) — a real `<button>`
+  when interactive (`onClick` set), a non-interactive `Badge` otherwise.
+- **Runtime flow**: `ColoredHashtagBubble` keeps its existing color-resolution logic
+  (`useHashtagColorResolver`) and prop contract, but renders the pill via `ChoiceChip`
+  instead of a hand-rolled `<span>`/`<button>`. `HashtagMultiSelect`'s selection grid
+  replaced `<label><input type="checkbox"/></label>` with `ChoiceChip`'s own
+  `active`/`onClick` (`aria-pressed` under the hood) — GDS's `ChoiceChip` is explicitly
+  documented upstream for "lightweight selection, mode toggles, and taxonomy links".
+- **Props contract**: unchanged externally for `ColoredHashtagBubble`
+  (`hashtag`/`small`/`interactive`/`onClick`/`removable`/`onRemove`/`categoryColor`/
+  `projectCategorizedHashtags`/`autoResolveColor`) — all 14 existing call sites work as-is.
+- **Accessibility behavior**: interactive chips are real `<button>`s (native keyboard
+  reachability, focus state, `aria-pressed` on selection chips). An `interactive` +
+  `removable` chip can't nest a second real button (invalid HTML), so in that combination
+  the "×" is decorative (`aria-hidden`) and the whole chip removes on click — only used
+  where `onClick`/`onRemove` already invoke the same handler. A `removable`-only chip
+  keeps a real, independently focusable/labelled remove `<button>`.
+- **Mobile behavior**: `ChoiceChip` touch targets match GDS's own sizing; the selection
+  grid still wraps via `HashtagMultiSelect.module.css`'s `.hashtagsGrid`
+  (`repeat(auto-fill, minmax(280px, 1fr))`), unchanged.
+- **States**: disabled forwards to the underlying `<button>` (verified: `ChoiceChip`'s
+  Mantine `Badge` is polymorphic and forwards unrecognized props to the DOM element it
+  renders as, even though its own TS type doesn't declare `disabled`/`title`). No
+  loading/empty/error state applies to a display chip.
+- **Verification**: `npm run lint`, `npm run type-check`, `npm test`, `npm run build`
+  all clean; manually verified via a temporary scratch route (deleted before commit) —
+  display/removable/interactive+removable bubbles, the selection grid's active/light
+  variant swap on click, and the selected-filters row's remove-on-click, all screenshot-
+  and interaction-tested with headless Chromium.
 
 If a new local wrapper is needed, document:
 

--- a/docs/guides/guides-form-input-migration-guide.md
+++ b/docs/guides/guides-form-input-migration-guide.md
@@ -4,7 +4,7 @@ Last Updated: 2026-01-11T22:28:38.000Z
 Canonical: No
 Owner: Product
 
-**Version**: 12.1.38
+**Version**: 12.1.39
 **Last Updated**: 2026-01-11T22:28:38.000Z
 **Purpose**: Prevent aggressive parsing anti-patterns in future forms
 

--- a/docs/guides/guides-input-system-complete.md
+++ b/docs/guides/guides-input-system-complete.md
@@ -5,7 +5,7 @@ Canonical: No
 Owner: Product
 
 **Date**: 2025-12-25T20:50:00.000Z
-**Version**: 12.1.38
+**Version**: 12.1.39
 **Status**: ✅ Complete - Production Ready
 
 ## 📋 Overview

--- a/docs/low-level-design.md
+++ b/docs/low-level-design.md
@@ -4,7 +4,7 @@ Last Updated: 2026-06-25T00:00:00.000Z
 Canonical: No
 Owner: Architecture
 
-Version: 12.1.38
+Version: 12.1.39
 
 This document captures implementation-level contracts for recently changed high-risk flows. It complements `docs/architecture.md`; it does not replace feature specs or API references.
 

--- a/docs/operations/operations-release-notes.md
+++ b/docs/operations/operations-release-notes.md
@@ -37,6 +37,13 @@ hashtag system.
   baseline alignment stretched the chip's line box (measured ~32px vs the chip's own
   ~18px height) and got clipped by the chip's `overflow: hidden`, visually overlapping
   the hashtag text.
+- Fixed a real accessibility bug found via automated PR review: the initial version
+  hardcoded `aria-label="Toggle {hashtag} filter"` on every `interactive` chip, but
+  `ColoredHashtagBubble` is reused for other actions too (`app/admin/events/
+  ProjectsPageClient.tsx` uses it to open a share popup, not toggle a filter) — screen
+  readers would announce the wrong action there. Added an optional `ariaLabel` prop
+  instead: omitted, the chip's visible text (`#hashtag`) is the accessible name (always
+  accurate); callers pass it when they need a more specific description.
 - Docs: `docs/design/design-system.md` (new "Approved Local Patterns" entries +
   dedicated GDS-primitive/accessibility/verification writeup) and
   `docs/components/components-reusable-components-inventory.md` (`ColoredHashtagBubble`/

--- a/docs/operations/operations-release-notes.md
+++ b/docs/operations/operations-release-notes.md
@@ -1,8 +1,64 @@
 # {messmass} Release Notes
 Status: Active
-Last Updated: 2026-08-04T21:59:31.000Z
+Last Updated: 2026-08-08T16:40:43.000Z
 Canonical: No
 Owner: Operations
+
+## [v12.1.39] — 2026-08-08T16:40:43.000Z
+
+### Summary
+Migrated the hashtag chip UI (`ColoredHashtagBubble`, `HashtagMultiSelect`) from a
+hand-rolled `<span>`/`<button>` pattern to GDS's `ChoiceChip`
+(`@sovereignsquad/gds-core/client`), the last significant hand-rolled UI surface in the
+hashtag system.
+
+### What Was Delivered
+- `components/ColoredHashtagBubble.tsx` now renders through GDS's `ChoiceChip` instead
+  of a local `<span>`/`<button>` pill; `ColoredHashtagBubble.module.css` now only styles
+  the inline "×" remove affordance, not the chip shell (GDS owns padding/radius/color/
+  hover/focus/disabled/print). External prop contract unchanged — all 14 existing call
+  sites work as-is.
+- Fixed a real invalid-HTML nesting hazard this migration would otherwise introduce:
+  `interactive`+`removable` together used to safely nest a real `<button>` inside a
+  `<span>`; once the primitive renders `interactive` chips as a real `<button>`
+  (`ChoiceChip`'s `onClick` branch), that same combination would nest a button inside a
+  button. Resolved by making the "×" decorative (`aria-hidden`) whenever `interactive`
+  is set — the whole chip already removes on click in every call site that combines the
+  two, so behavior is unchanged.
+- `components/HashtagMultiSelect.tsx`'s selection grid replaced
+  `<label><input type="checkbox"/></label>` (wrapping a non-interactive bubble) with
+  `ChoiceChip`'s own `active`/`onClick` selection semantics (`aria-pressed` under the
+  hood) — the idiomatic GDS pattern for "lightweight selection, mode toggles, and
+  taxonomy links" per its own JSDoc. Each grid item composes a display-only
+  `ColoredHashtagBubble` (carries the per-hashtag category color) as the `ChoiceChip`'s
+  `label`, plus the count badge.
+- Found and fixed a real layout bug during verification: the inline remove `<button>`/
+  decorative "×" needed `vertical-align: middle` — without it, the `<button>`'s default
+  baseline alignment stretched the chip's line box (measured ~32px vs the chip's own
+  ~18px height) and got clipped by the chip's `overflow: hidden`, visually overlapping
+  the hashtag text.
+- Docs: `docs/design/design-system.md` (new "Approved Local Patterns" entries +
+  dedicated GDS-primitive/accessibility/verification writeup) and
+  `docs/components/components-reusable-components-inventory.md` (`ColoredHashtagBubble`/
+  `HashtagMultiSelect` entries updated with the new implementation and the
+  interactive+removable nesting rule).
+
+### Testing
+- `type-check`, `lint` (`--max-warnings 0`), `test`, `style:check`,
+  `check-dependency-guardrail`, `check-layout-grammar-guardrail`, and `build` all clean.
+- Fixed two test suites (`tests/admin-action-rail.test.tsx`,
+  `tests/mobile-admin-action-contract.test.ts`) that crashed at import time once
+  `ColoredHashtagBubble` started importing `@sovereignsquad/gds-core/client`: that
+  import transitively barrel-imports all of `@mantine/core` (including `Textarea`/
+  `JsonInput`, whose `react-textarea-autosize` dependency touches browser-only APIs at
+  module-load time), which this repo's `jest-environment-node` (no DOM, by design) can't
+  tolerate. Both suites only test unrelated adapter/action-rail logic that transitively
+  imports the adapters for other reasons, so `ColoredHashtagBubble` is mocked out in
+  those two files rather than changing the repo's test environment.
+- Live-verified via a temporary scratch route (deleted before commit) with headless
+  Chromium: display-only, removable-only, and interactive+removable bubbles; the
+  selection grid's active/light variant swap and `aria-pressed` on click; the
+  selected-filters row's remove-on-click; the vertical-align layout fix, before/after.
 
 ## [v12.1.38] — 2026-08-04T21:59:31.000Z
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "messmass",
-  "version": "12.1.38",
+  "version": "12.1.39",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "messmass",
-      "version": "12.1.38",
+      "version": "12.1.39",
       "license": "MIT",
       "dependencies": {
         "@mantine/core": "^8.3.18",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "messmass",
-  "version": "12.1.38",
+  "version": "12.1.39",
   "description": "Enterprise-grade event analytics platform with comprehensive partner management, intelligent link tracking, automated event creation (Sports Match Builder), and advanced real-time statistics dashboard for sports organizations, venues, brands, and event managers",
   "keywords": [
     "event-statistics",

--- a/tests/admin-action-rail.test.tsx
+++ b/tests/admin-action-rail.test.tsx
@@ -1,5 +1,19 @@
 import React from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
+
+// WHAT: ColoredHashtagBubble now renders through GDS's ChoiceChip
+// (@sovereignsquad/gds-core/client), which transitively barrel-imports all of
+// @mantine/core -- including Textarea/JsonInput, whose react-textarea-autosize
+// dependency touches browser-only APIs at module-load time. This suite runs under
+// jest-environment-node (no DOM), so merely importing the adapters below (which
+// import ColoredHashtagBubble for an unrelated column) crashes before any test
+// runs. Stub it out: this suite only asserts AdminActionRail's action-rail
+// behavior, never hashtag chip rendering.
+jest.mock('@/components/ColoredHashtagBubble', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
 import AdminActionRail from '@/components/admin/AdminActionRail';
 import { getAdminEntitySurfaceActions } from '@/lib/adminEntitySystem';
 import { organizationsEntityConfig } from '@/lib/adapters/organizationsAdapter';

--- a/tests/mobile-admin-action-contract.test.ts
+++ b/tests/mobile-admin-action-contract.test.ts
@@ -1,3 +1,16 @@
+// WHAT: ColoredHashtagBubble now renders through GDS's ChoiceChip
+// (@sovereignsquad/gds-core/client), which transitively barrel-imports all of
+// @mantine/core -- including Textarea/JsonInput, whose react-textarea-autosize
+// dependency touches browser-only APIs at module-load time. This suite runs under
+// jest-environment-node (no DOM), so merely importing the adapters below (which
+// import ColoredHashtagBubble for an unrelated column) crashes before any test
+// runs. Stub it out: this suite only asserts adapter.listConfig.columns shape,
+// never hashtag chip rendering.
+jest.mock('@/components/ColoredHashtagBubble', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
 import { organizationsAdapter } from '@/lib/adapters/organizationsAdapter';
 import { partnersAdapter } from '@/lib/adapters/partnersAdapter';
 import { projectsAdapter } from '@/lib/adapters/projectsAdapter';


### PR DESCRIPTION
## Context

**Branch:** `feature/hashtag-chip-gds-migration`
**Base:** `main`

The hashtag chip UI (`ColoredHashtagBubble`, `HashtagMultiSelect`) was the last significant hand-rolled surface in the hashtag system — a local `<span>`/`<button>` pill and a checkbox+label selection grid, instead of GDS's `ChoiceChip`.

## Changes

**What changed:**
- `components/ColoredHashtagBubble.tsx` now renders through GDS's `ChoiceChip` (`@sovereignsquad/gds-core/client`) instead of a hand-rolled pill. `ColoredHashtagBubble.module.css` now only styles the inline "×" remove affordance — GDS owns the chip shell (padding/radius/color/hover/focus/disabled/print). External prop contract is unchanged; all 14 existing call sites work as-is.
- `components/HashtagMultiSelect.tsx`'s selection grid replaces `<label><input type="checkbox"/></label>` with `ChoiceChip`'s own `active`/`onClick` selection semantics (`aria-pressed` under the hood) — GDS's own documented purpose for the component ("lightweight selection, mode toggles, and taxonomy links"). Each grid item composes a display-only `ColoredHashtagBubble` (keeps the per-hashtag category color) as the chip's `label`, plus the count.
- `docs/design/design-system.md` and `docs/components/components-reusable-components-inventory.md` updated with the new implementation, including a documented rule for future maintainers (see below).
- Version `12.1.38` → `12.1.39` (package.json/package-lock.json, all current-doc version headers, `docs/operations/operations-release-notes.md`).

**Why:**
- Closes the last hand-rolled surface in the hashtag system per the design system's own mandate ("Use GDS components and vocabulary before creating local UI").

**How:**
- A real, structural HTML-nesting hazard had to be solved, not just a mechanical swap: `interactive`+`removable` together used to safely nest a real `<button>` inside a `<span>`. Once the primitive renders `interactive` chips as a real `<button>` (`ChoiceChip`'s `onClick` branch), that combination would nest a button inside a button — invalid HTML. Fixed by making the "×" decorative (`aria-hidden`) whenever `interactive` is set; the whole chip already removes on click at every site that combines the two (`onClick`/`onRemove` invoke the same handler there), so behavior is unchanged.
- Found and fixed a real layout bug during verification: the remove `<button>`/decorative "×" needed `vertical-align: middle` — without it, the button's default baseline alignment stretched the chip's line box (~32px measured vs. the chip's own ~18px height) and got clipped by the chip's `overflow: hidden`, visually overlapping the hashtag text.
- Fixed two test suites (`tests/admin-action-rail.test.tsx`, `tests/mobile-admin-action-contract.test.ts`) that crashed at import time once `ColoredHashtagBubble` started importing `@sovereignsquad/gds-core/client` — that import transitively barrel-imports all of `@mantine/core` (including `Textarea`/`JsonInput`, whose `react-textarea-autosize` dependency touches browser-only APIs at module-load time), which this repo's `jest-environment-node` (no DOM, by design) can't tolerate. Neither suite exercises hashtag chip rendering, so `ColoredHashtagBubble` is mocked out in those two files rather than changing the repo's test environment.

## Verification

**Tests:**
- [x] All existing tests pass (309/309, including the 2 previously-crashing suites, now fixed)
- Manual/visual verification in lieu of new automated coverage (no test infra exists for visual/DOM rendering in this repo — tests run under `jest-environment-node`)

**Manual Testing:**
- [x] Tested locally via a temporary scratch route (deleted before this commit) + headless Chromium: display-only, removable-only, and interactive+removable bubbles; the selection grid's active/light variant swap and click-to-toggle; the selected-filters row's remove-on-click; the vertical-align fix, before/after screenshots
- [ ] Verified in preview deployment (not done from this environment — no egress to this repo's MongoDB Atlas cluster from this sandbox; same limitation noted in the v12.1.38 tour release notes)
- [x] No console errors beyond the expected sandbox-only MongoDB connection timeout (no Atlas egress here), unrelated to this change

**CI Status:**
- [x] Locally green: `type-check`, `lint` (`--max-warnings 0`), `test`, `style:check`, `version:verify`, `docs:audit`, `check-dependency-guardrail`, `check-layout-grammar-guardrail`, `build` — the exact steps `.github/workflows/ci.yml` runs

## Impact

**Breaking Changes:** None — `ColoredHashtagBubble`'s external prop contract is unchanged.

**Performance:** No measurable impact expected (same component count, same render logic).

**Security:** None.

## Documentation

- [x] `docs/design/design-system.md` — new "Approved Local Patterns" entries + GDS-primitive/accessibility/verification writeup
- [x] `docs/components/components-reusable-components-inventory.md` — updated `ColoredHashtagBubble`/new `HashtagMultiSelect` entries, including the interactive+removable nesting rule for future maintainers
- [x] `docs/operations/operations-release-notes.md` — new `[v12.1.39]` entry