### PR TITLE
Restrict Drive folder endpoints to admin role, fix nested-form bugs

### DIFF
--- a/app/api/drive-folders/[linkId]/route.ts
+++ b/app/api/drive-folders/[linkId]/route.ts
@@ -6,9 +6,17 @@
 // ENDPOINT: DELETE ?projectId=
 
 import { NextRequest, NextResponse } from 'next/server';
-import { getAdminUser } from '@/lib/auth';
+import { getAdminUser, type AdminUser } from '@/lib/auth';
 import { removeDriveFolder } from '@/lib/driveFolders';
 import { error as logError } from '@/lib/logger';
+
+// Same admin-role check used by other admin-scoped routes (e.g.
+// app/api/admin/projects/route.ts) — getAdminUser() only proves a valid
+// session exists, not that the role is actually admin (UserRole also
+// includes 'guest'/'user'/'api').
+function isAdmin(user: AdminUser | null): user is AdminUser {
+  return user !== null && (user.role === 'admin' || user.role === 'superadmin');
+}
 
 export async function DELETE(
   request: NextRequest,
@@ -16,7 +24,7 @@ export async function DELETE(
 ) {
   try {
     const user = await getAdminUser();
-    if (!user) {
+    if (!isAdmin(user)) {
       return NextResponse.json({ success: false, error: 'Unauthorized' }, { status: 401 });
     }
 

--- a/app/api/drive-folders/route.ts
+++ b/app/api/drive-folders/route.ts
@@ -9,14 +9,22 @@
 //   POST              - Add a Drive folder link to an event
 
 import { NextRequest, NextResponse } from 'next/server';
-import { getAdminUser } from '@/lib/auth';
+import { getAdminUser, type AdminUser } from '@/lib/auth';
 import { addDriveFolder, listDriveFolders } from '@/lib/driveFolders';
 import { error as logError } from '@/lib/logger';
+
+// Same admin-role check used by other admin-scoped routes (e.g.
+// app/api/admin/projects/route.ts) — getAdminUser() only proves a valid
+// session exists, not that the role is actually admin (UserRole also
+// includes 'guest'/'user'/'api').
+function isAdmin(user: AdminUser | null): user is AdminUser {
+  return user !== null && (user.role === 'admin' || user.role === 'superadmin');
+}
 
 export async function GET(request: NextRequest) {
   try {
     const user = await getAdminUser();
-    if (!user) {
+    if (!isAdmin(user)) {
       return NextResponse.json({ success: false, error: 'Unauthorized' }, { status: 401 });
     }
 
@@ -41,7 +49,7 @@ export async function GET(request: NextRequest) {
 export async function POST(request: NextRequest) {
   try {
     const user = await getAdminUser();
-    if (!user) {
+    if (!isAdmin(user)) {
       return NextResponse.json({ success: false, error: 'Unauthorized' }, { status: 401 });
     }
 

--- a/components/DriveFoldersEditor.tsx
+++ b/components/DriveFoldersEditor.tsx
@@ -149,8 +149,14 @@ export default function DriveFoldersEditor({ projectId, projectName }: DriveFold
               value={newFolderUrl}
               onChange={(e) => setNewFolderUrl(e.target.value)}
               onKeyDown={(e) => {
-                if (e.key === 'Enter' && previewFolderId) {
-                  e.preventDefault();
+                // This input still lives inside FormModal's own outer <form>
+                // (only the add-panel wrapper stopped being one). preventDefault
+                // unconditionally on Enter so an invalid-but-non-empty value —
+                // which still satisfies the native `required` constraint — can
+                // never fall through to the outer form's implicit submit.
+                if (e.key !== 'Enter') return;
+                e.preventDefault();
+                if (previewFolderId) {
                   handleAddLink();
                 }
               }}

--- a/components/DriveFoldersEditor.tsx
+++ b/components/DriveFoldersEditor.tsx
@@ -69,8 +69,7 @@ export default function DriveFoldersEditor({ projectId, projectName }: DriveFold
   const previewFolderId = newFolderUrl.trim() ? extractDriveFolderId(newFolderUrl) : null;
   const showInvalidHint = newFolderUrl.trim().length > 0 && !previewFolderId;
 
-  async function handleAddLink(e: React.FormEvent) {
-    e.preventDefault();
+  async function handleAddLink() {
     setError('');
     setSuccess('');
 
@@ -138,13 +137,23 @@ export default function DriveFoldersEditor({ projectId, projectName }: DriveFold
       {error && <div className={styles.error}>{error}</div>}
       {success && <div className={styles.success}>{success}</div>}
 
+      {/* A plain div, not a <form> — this editor is embedded inside FormModal's
+          own <form>, and a nested form is invalid HTML whose submit can bubble
+          to the outer modal's submit handler. type="button" + onClick keeps
+          this action fully independent of the surrounding form. */}
       {showAddForm && (
-        <form onSubmit={handleAddLink} className={styles.addForm}>
+        <div className={styles.addForm}>
           <div className={styles.inputGroup}>
             <input
               type="text"
               value={newFolderUrl}
               onChange={(e) => setNewFolderUrl(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' && previewFolderId) {
+                  e.preventDefault();
+                  handleAddLink();
+                }
+              }}
               placeholder="Paste a Google Drive folder link"
               className={styles.input}
               required
@@ -155,10 +164,15 @@ export default function DriveFoldersEditor({ projectId, projectName }: DriveFold
               </p>
             )}
           </div>
-          <button type="submit" className={styles.submitButton} disabled={!previewFolderId}>
+          <button
+            type="button"
+            onClick={handleAddLink}
+            className={styles.submitButton}
+            disabled={!previewFolderId}
+          >
             Add
           </button>
-        </form>
+        </div>
       )}
 
       {loading ? (
@@ -193,6 +207,7 @@ export default function DriveFoldersEditor({ projectId, projectName }: DriveFold
                 </div>
               </div>
               <button
+                type="button"
                 onClick={() => handleRemoveLink(link._id, link.folderUrl)}
                 className={styles.removeButton}
                 title="Remove from this event"


### PR DESCRIPTION
## What changed

Follow-up to #319, which merged before this review feedback (from an automated Codex review) landed. Fixes three real issues in the just-merged Drive-folder-linking feature:

1. **Admin-role check on `/api/drive-folders/**`.** `getAdminUser()` only proves a valid session exists — `UserRole` includes `guest`/`user`/`api`, not just `admin`/`superadmin`, so the new endpoints were reachable by any authenticated account, not just admins. Adds the same `isAdmin()` role check already used by other admin-scoped routes (e.g. `app/api/admin/projects/route.ts`).
2. **Nested `<form>` in `DriveFoldersEditor`.** The add-folder form was a `<form>` nested inside `FormModal`'s own `<form>` — invalid HTML, and the inner submit could bubble to the outer modal's submit handler. Converted to a plain `<div>` with an explicit `type="button"` + `onClick`, plus an `onKeyDown` handler so Enter-to-submit still works.
3. **Remove button missing `type="button"`.** Defaulted to `type="submit"` inside the same outer form, so clicking it could also trigger the outer form's submit.

## Testing

- `npm run type-check` — clean
- `npm run lint` — clean
- `npm run build` — clean